### PR TITLE
Clean-up built-in scope conditionals

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ step.run_if = False
 step.skip_if = True, "Step disabled"
 
 # Context-aware callable
-step.run_if = lambda context: len(context.get_exceptions()) != 0
+step.run_if = lambda context: len(context.get_errors()) != 0
 ```
 
 Built-in condition helpers:

--- a/src/rkojob/__init__.py
+++ b/src/rkojob/__init__.py
@@ -259,16 +259,16 @@ class JobContext(Protocol):
     @property
     def scopes(self) -> Tuple[JobScope, ...]: ...
 
-    def exception(self, error: str | Exception) -> Exception: ...
+    def error(self, error: str | Exception) -> Exception: ...
 
     """
-    Record *exception* in the current scope.
+    Record *error* in the current scope.
 
     :param error: And exception or error message.
     :returns: The exception instance or the error message as an exception.
     """
 
-    def get_exceptions(self, scope: JobScope | None = None) -> list[Exception]: ...
+    def get_errors(self, scope: JobScope | None = None) -> list[Exception]: ...
     @property
     def values(self) -> Values: ...
     @property
@@ -586,22 +586,22 @@ job_never = _JobScopeCondition(lambda _: False, "Never")
 """Scope condition that always returns ``False``."""
 
 
-job_failing = _JobScopeCondition(lambda context: bool(context.get_exceptions()), "Job has failures.")
+job_failing = _JobScopeCondition(lambda context: bool(context.get_errors()), "Job has failures.")
 """Scope condition that returns ``True`` if *any* errors have been recorded."""
 
 
-job_succeeding = _JobScopeCondition(lambda context: bool(not context.get_exceptions()), "Job is succeeding.")
+job_succeeding = _JobScopeCondition(lambda context: bool(not context.get_errors()), "Job is succeeding.")
 """Scope condition that returns ``True`` if *no* errors have been recorded."""
 
 
 def scope_failing(scope: JobScope) -> JobCallable[JobConditionalValueType]:
     """Scope condition that returns ``True`` if errors have been recorded for the provided `scope`."""
-    return _JobScopeCondition(lambda context: bool(context.get_exceptions(scope)), f"{scope} has failures.")
+    return _JobScopeCondition(lambda context: bool(context.get_errors(scope)), f"{scope} has failures.")
 
 
 def scope_succeeding(scope: JobScope) -> JobCallable[JobConditionalValueType]:
     """Scope condition that returns ``True`` if *no* errors have been recorded for the provided `scope`."""
-    return _JobScopeCondition(lambda context: bool(not context.get_exceptions(scope)), f"{scope} is succeeding.")
+    return _JobScopeCondition(lambda context: bool(not context.get_errors(scope)), f"{scope} is succeeding.")
 
 
 @runtime_checkable

--- a/src/rkojob/context.py
+++ b/src/rkojob/context.py
@@ -609,9 +609,9 @@ class JobContextImpl:
             raise JobException(f"No state found for scope '{scope.name}'")
         return state
 
-    def exception(self, error: str | Exception) -> Exception:
+    def error(self, error: str | Exception) -> Exception:
         """
-        Record *exception* in the current scope.
+        Record *error* in the current scope.
 
         :param error: And exception or error message.
         :returns: The exception instance or the error message as an exception.
@@ -621,7 +621,7 @@ class JobContextImpl:
         self.status.error(error)
         return error
 
-    def get_exceptions(self, scope: JobScope | None = None) -> list[Exception]:
+    def get_errors(self, scope: JobScope | None = None) -> list[Exception]:
         """
         Return exceptions recorded for *scope* or for *all* scopes if omitted.
 

--- a/src/rkojob/runner.py
+++ b/src/rkojob/runner.py
@@ -29,9 +29,9 @@ class JobRunnerImpl:
         :param scope: The scope to run.
         """
         self._run_scope(context, scope)
-        exceptions: list[Exception] = context.get_exceptions()
-        if exceptions:
-            raise JobException("\n".join([str(e) for e in exceptions]))
+        errors: list[Exception] = context.get_errors()
+        if errors:
+            raise JobException("\n".join([str(e) for e in errors]))
 
     def _run_scope(self, context: JobContext, scope: JobScope) -> None:
         # Run and then teardown a scope.

--- a/tests/test_rkojob/test_context.py
+++ b/tests/test_rkojob/test_context.py
@@ -563,12 +563,12 @@ class TestJobContextImpl(TestCase):
             self.assertEqual((mock_scope_1,), sut.scopes)
         self.assertEqual(tuple(), sut.scopes)
 
-    def test_exception(self):
-        self.assertEqual("JobException('Foo')", repr(JobContextImpl().exception("Foo")))
+    def test_error(self):
+        self.assertEqual("JobException('Foo')", repr(JobContextImpl().error("Foo")))
         bar_exception = Exception("Bar")
-        self.assertEqual(bar_exception, JobContextImpl().exception(bar_exception))
+        self.assertEqual(bar_exception, JobContextImpl().error(bar_exception))
 
-    def test_get_exceptions(self):
+    def test_get_errors(self):
         sut = JobContextImpl()
 
         foo_error = Exception("Foo")
@@ -592,9 +592,9 @@ class TestJobContextImpl(TestCase):
         sut.status.error(boz_error)
         sut.status.finish_scope(mock_scope)
 
-        self.assertEqual([foo_error, bar_error, baz_error, boz_error, buz_error], sut.get_exceptions())
-        self.assertEqual([baz_error, boz_error, buz_error], sut.get_exceptions(mock_scope))
-        self.assertEqual([buz_error], sut.get_exceptions(mock_scope_2))
+        self.assertEqual([foo_error, bar_error, baz_error, boz_error, buz_error], sut.get_errors())
+        self.assertEqual([baz_error, boz_error, buz_error], sut.get_errors(mock_scope))
+        self.assertEqual([buz_error], sut.get_errors(mock_scope_2))
 
     def test_values(self) -> None:
         sut = JobContextImpl()

--- a/tests/test_rkojob/test_rkojob.py
+++ b/tests/test_rkojob/test_rkojob.py
@@ -417,18 +417,16 @@ class TestJobScopeCondition(TestCase):
     def test_job_failing(self) -> None:
         sut = job_failing
         self.assertEqual("Job has failures.", repr(sut))
-        self.assertEqual(
-            (True, "Job has failures."), sut(MagicMock(get_exceptions=MagicMock(return_value=[Exception()])))
-        )
-        self.assertEqual((False, "Job has failures."), sut(MagicMock(get_exceptions=MagicMock(return_value=[]))))
+        self.assertEqual((True, "Job has failures."), sut(MagicMock(get_errors=MagicMock(return_value=[Exception()]))))
+        self.assertEqual((False, "Job has failures."), sut(MagicMock(get_errors=MagicMock(return_value=[]))))
 
     def test_job_succeeding(self) -> None:
         sut = job_succeeding
         self.assertEqual("Job is succeeding.", repr(sut))
         self.assertEqual(
-            (False, "Job is succeeding."), sut(MagicMock(get_exceptions=MagicMock(return_value=[Exception()])))
+            (False, "Job is succeeding."), sut(MagicMock(get_errors=MagicMock(return_value=[Exception()])))
         )
-        self.assertEqual((True, "Job is succeeding."), sut(MagicMock(get_exceptions=MagicMock(return_value=[]))))
+        self.assertEqual((True, "Job is succeeding."), sut(MagicMock(get_errors=MagicMock(return_value=[]))))
 
     def test_scope_failing(self) -> None:
         mock_context = MagicMock()
@@ -438,15 +436,15 @@ class TestJobScopeCondition(TestCase):
         sut = scope_failing(mock_scope)
         self.assertEqual("Scope has failures.", repr(sut))
 
-        mock_context.get_exceptions.return_value = [Exception()]
+        mock_context.get_errors.return_value = [Exception()]
         self.assertEqual((True, "Scope has failures."), sut(mock_context))
-        mock_context.get_exceptions.assert_called_with(mock_scope)
+        mock_context.get_errors.assert_called_with(mock_scope)
 
         mock_context.reset_mock()
-        mock_context.get_exceptions.return_value = []
+        mock_context.get_errors.return_value = []
 
         self.assertEqual((False, "Scope has failures."), sut(mock_context))
-        mock_context.get_exceptions.assert_called_with(mock_scope)
+        mock_context.get_errors.assert_called_with(mock_scope)
 
     def test_scope_succeeding(self) -> None:
         mock_context = MagicMock()
@@ -456,12 +454,12 @@ class TestJobScopeCondition(TestCase):
         sut = scope_succeeding(mock_scope)
         self.assertEqual("Scope is succeeding.", repr(sut))
 
-        mock_context.get_exceptions.return_value = [Exception()]
+        mock_context.get_errors.return_value = [Exception()]
         self.assertEqual((False, "Scope is succeeding."), sut(mock_context))
-        mock_context.get_exceptions.assert_called_with(mock_scope)
+        mock_context.get_errors.assert_called_with(mock_scope)
 
         mock_context.reset_mock()
-        mock_context.get_exceptions.return_value = []
+        mock_context.get_errors.return_value = []
 
         self.assertEqual((True, "Scope is succeeding."), sut(mock_context))
-        mock_context.get_exceptions.assert_called_with(mock_scope)
+        mock_context.get_errors.assert_called_with(mock_scope)


### PR DESCRIPTION
Minor clean-up:

- Make built-in scope conditionals (ex. `job_failing`, `scope_succeeding`) instances of `_JobContextConditional`.
- More improvements to README.md
- Rename `JobContext` methods `exception()` and `get_exceptions()` to `error()` and `get_errors()`.