### PR TITLE
Introduce JobScopeID protocol used to refer to scopes before creation.

### DIFF
--- a/tests/test_rkojob/test_rkojob.py
+++ b/tests/test_rkojob/test_rkojob.py
@@ -16,6 +16,7 @@ from rkojob import (
     ValueKey,
     assign_value,
     context_value,
+    create_scope_id,
     job_always,
     job_failing,
     job_never,
@@ -39,6 +40,12 @@ class TestJobException(TestCase):
             raise JobException("error")
         except JobException as e:
             self.assertEqual("error", str(e))
+
+
+class TestCreateScopeId(TestCase):
+    def test(self) -> None:
+        self.assertEqual(36, len(create_scope_id()))
+        self.assertNotEqual(create_scope_id(), create_scope_id())
 
 
 class TestJobBaseStatus(TestCase):

--- a/tests/test_rkojob/test_writer.py
+++ b/tests/test_rkojob/test_writer.py
@@ -28,9 +28,10 @@ from rkojob.writer import (
 
 
 class StubScope:
-    def __init__(self, name, type):
+    def __init__(self, name, type, id=None):
         self.name = name
         self.type = type
+        self.id = id or name
 
 
 class TestOutputEvent(TestCase):


### PR DESCRIPTION
Introduce a `JobScipeID` protocol that `JobScope` inherits and `JobBuilder`, `JobStageBuilder`, and `JobStepBuilder` conform to. When building a new job/stage/step, the builder creates a unique ID for the not-yet-formed scope. When the scope is created the ID is assigned to it. Since both the builder and the built scope have the same ID, this allows them to be used interchangeably in certain contexts. For example:

```python
stage_builder = JobStageBuilder("stage")
stage = stage_builder()

# These two conditions are effectively the same
condition = scope_failing(stage_builder)
condition2 = scope_failing(stage)
```

This fixes #12 because this pattern didn't work as expected before:

```python
with JobBuilder("job") as job:
    with job.stage("stage") as stage:
        with stage.step("step") as step:
            # Only run if this stage is failing
            step.run_if = scope_failing(stage)
```

Because `stage` is a `JobStageBuilder` instance, the `scope_failing()` condition would never return `True` because there would never be any errors associated with the builder in the context. Now that both `stage` and the real `JobStage` used at runtime have the same ID, the condition will resolve correctly.