### PR TITLE
A few minor follow ups to recent event-driven changes

### DIFF
--- a/src/rkojob/__init__.py
+++ b/src/rkojob/__init__.py
@@ -186,27 +186,13 @@ class JobContext(Protocol):
     def remove_teardown(self, scope: JobScopeID, teardown: JobCallable[None]) -> None: ...
     def get_teardown(self, scope: JobScopeID) -> Delegate[[JobContext], None]: ...
     def error(self, error: str | Exception) -> Exception: ...
-
-    """
-    Record *error* in the current scope.
-
-    :param error: And exception or error message.
-    :returns: The exception instance or the error message as an exception.
-    """
-
-    def get_errors(self, scope: JobScopeID | None = None) -> list[Exception]: ...
+    def get_errors(self, scope: JobScopeID | None = ...) -> list[Exception]: ...
+    def get_report(self, scope: JobScopeID | None = ...) -> dict[JobScopeID, Any]: ...
     @property
     def values(self) -> Values: ...
     @property
     def events(self) -> JobStatus: ...
     def get_scope_status(self, scope: JobScopeID) -> JobScopeStatus: ...
-
-    """
-    Return exceptions recorded for *scope* or for *all* scopes if omitted.
-
-    :param scope: Scope to return exceptions for, or ``None`` to get all exceptions.
-    :returns: List of recorded exceptions.
-    """
 
 
 def create_scope_id() -> str:

--- a/src/rkojob/__init__.py
+++ b/src/rkojob/__init__.py
@@ -54,8 +54,8 @@ class JobException(Exception):
 class JobEvent:
     type: str
 
-    def __init__(self, context: JobContextID, scope: JobScopeID | None, **data) -> None:
-        self.context: JobContextID = context
+    def __init__(self, context: JobContext, scope: JobScopeID | None, **data) -> None:
+        self.context: JobContext = context
         self.scope: JobScopeID | None = scope
         self.timestamp: datetime = datetime.now()
         self.data: dict[str, Any] = data
@@ -154,14 +154,14 @@ class JobScopeStatus(Enum):
     UNKNOWN = auto()
 
 
-JobContextID: TypeAlias = str
+JobIdType: TypeAlias = str
 
 
-def create_context_id() -> JobContextID:
+def create_context_id() -> JobIdType:
     """
     Creates a new, unique context ID value.
     """
-    return JobContextID(uuid4())
+    return JobIdType(uuid4())
 
 
 class JobContext(Protocol):
@@ -174,7 +174,7 @@ class JobContext(Protocol):
     """
 
     @property
-    def id(self) -> JobContextID: ...
+    def id(self) -> JobIdType: ...
     def push_scope(self, scope: JobScope) -> None: ...
     def pop_scope(self) -> JobScope: ...
     @property
@@ -195,11 +195,11 @@ class JobContext(Protocol):
     def get_scope_status(self, scope: JobScopeID) -> JobScopeStatus: ...
 
 
-def create_scope_id() -> str:
+def create_scope_id() -> JobIdType:
     """
     Creates a new, unique scope ID value.
     """
-    return str(uuid4())
+    return JobIdType(uuid4())
 
 
 @runtime_checkable
@@ -209,7 +209,7 @@ class JobScopeID(Protocol):
     """
 
     @property
-    def id(self) -> str: ...
+    def id(self) -> JobIdType: ...
 
 
 class JobScopeType(Protocol):

--- a/src/rkojob/__init__.py
+++ b/src/rkojob/__init__.py
@@ -267,6 +267,9 @@ class JobScopeStackNode(Generic[K, V]):
         self.key: K = key
         self.value: V = value
         self.parent: JobScopeStackNode[K, V] | None = parent
+        self.children: list[JobScopeStackNode[K, V]] = []
+        if self.parent:
+            self.parent.children.append(self)
 
 
 class JobScopeStack(Generic[K, V], Mapping[K, V]):
@@ -295,13 +298,16 @@ class JobScopeStack(Generic[K, V], Mapping[K, V]):
             raise JobException("Scope stack underflow.")
         node: JobScopeStackNode[K, V] = self._node
         self._node = self._node.parent
-        self._nodes.pop(node.key)
         return node.key, node.value
 
     def peek(self) -> tuple[K, V]:
         if self._node is None:
             raise JobException("Scope stack underflow.")
         return self._node.key, self._node.value
+
+    @property
+    def all_nodes(self) -> dict[K, JobScopeStackNode[K, V]]:
+        return self._nodes
 
     def get_scope(self) -> K | None:
         if self._node is None:
@@ -324,6 +330,18 @@ class JobScopeStack(Generic[K, V], Mapping[K, V]):
             node = node.parent
         return tuple(reversed(path))
 
+    def children_of(self, key: K, depth: int | None = None) -> tuple[K, ...]:
+        children: list[K] = []
+        if depth is None or depth > 0:
+            node: JobScopeStackNode[K, V] | None = self._nodes.get(key)
+            if node:
+                if depth is not None:
+                    depth -= 1
+                for child in node.children:
+                    children.append(child.key)
+                    children.extend(self.children_of(child.key, depth=depth))
+        return tuple(children)
+
     def fork(self) -> JobScopeStack[K, V]:
         fork: JobScopeStack[K, V] = type(self)()
         fork._node = self._node
@@ -340,7 +358,7 @@ class JobScopeStack(Generic[K, V], Mapping[K, V]):
         return self._nodes[key].value
 
     def __len__(self) -> int:
-        return len(self._nodes)
+        return sum(1 for _ in self)
 
     def __iter__(self) -> Iterator[K]:
         node: JobScopeStackNode[K, V] | None = self._node

--- a/src/rkojob/context.py
+++ b/src/rkojob/context.py
@@ -107,7 +107,6 @@ class JobContextImpl(JobContext):
         # State that pushes and pops with the scope.
         self._id: JobContextID = create_context_id()
         self._scope_stack: JobScopeStack[JobScope, JobScopeState] = JobScopeStack(default_factory=JobScopeState)
-        self._known_scopes: dict[str, JobScope] = {}
 
         if values is None:
             values = {}
@@ -141,7 +140,6 @@ class JobContextImpl(JobContext):
         :param scope: The scope to push.
         """
         self._scope_stack.push(scope)
-        self._known_scopes[scope.id] = scope
 
     def pop_scope(self) -> JobScope:
         """
@@ -235,10 +233,14 @@ class JobContextImpl(JobContext):
             # Scope ID is the scope itself.
             return scope_id
 
-        if scope_id.id not in self._known_scopes:
-            raise JobException(f"Scope with ID '{scope_id.id}' is not known to this context.")
+        if scope_id in self._scope_stack.all_nodes:
+            return self._scope_stack.all_nodes[scope_id].key  # type: ignore[index]
 
-        return self._known_scopes[scope_id.id]
+        for scope in self._scope_stack.all_nodes:
+            if scope_id.id == scope.id:
+                return scope
+
+        raise JobException(f"Scope with ID '{scope_id.id}' is not known to this context.")
 
     @property
     def events(self) -> JobStatus:

--- a/src/rkojob/context.py
+++ b/src/rkojob/context.py
@@ -13,11 +13,11 @@ from typing import (
 from rkojob import (
     JobCallable,
     JobContext,
-    JobContextID,
     JobEvent,
     JobEventDispatcher,
     JobEventHandler,
     JobException,
+    JobIdType,
     JobScope,
     JobScopeID,
     JobScopeStack,
@@ -128,7 +128,7 @@ class JobScopeState:
 class JobContextImpl(JobContext):
     def __init__(self, *, values: dict[str, Any] | None = None, status_writer: JobStatusWriter | None = None) -> None:
         # State that pushes and pops with the scope.
-        self._id: JobContextID = create_context_id()
+        self._id: JobIdType = create_context_id()
         self._scope_stack: JobScopeStack[JobScope, JobScopeState] = JobScopeStack(default_factory=JobScopeState)
 
         if values is None:
@@ -146,11 +146,11 @@ class JobContextImpl(JobContext):
             self._events.add_handler(status_writer)
 
     @property
-    def id(self) -> JobContextID:
+    def id(self) -> JobIdType:
         return self._id
 
     def handle(self, event: JobEvent):
-        if event.context == self.id:
+        if event.context.id == self.id:
             if isinstance(event, JobStartScopeEvent):
                 self.push_scope(self._resolve_scope(event.started_scope))
             elif isinstance(event, JobFinishScopeEvent):

--- a/src/rkojob/context.py
+++ b/src/rkojob/context.py
@@ -46,19 +46,44 @@ class JobScopeStatuses(JobEventHandler):
     """
 
     def __init__(self) -> None:
-        self._scope_stack: JobScopeStack[JobScopeID, None] = JobScopeStack()
+        self._scope_stack: JobScopeStack[JobScopeID, list[str | Exception]] = JobScopeStack(default_factory=list)
         self._statuses: dict[JobScopeID, JobScopeStatus] = {}
-        self._errors: dict[tuple[JobScopeID, ...], list[str | Exception]] = {}
+        self._global_errors: list[str | Exception] = []
 
     def get_status(self, scope: JobScopeID) -> JobScopeStatus:
         return self._statuses.get(scope, JobScopeStatus.UNKNOWN)
 
     def get_errors(self, scope: JobScopeID | None = None) -> list[str | Exception]:
         errors: list[str | Exception] = []
-        for scopes in self._errors:
-            if scope is None or scope in scopes:
-                errors.extend(self._errors[scopes])
+        scopes: list[JobScopeID]
+        if scope is None:
+            scopes = list(self._scope_stack.all_nodes)
+        else:
+            scopes = [scope, *self._scope_stack.children_of(scope)]
+
+        for key in reversed(scopes):
+            errs = self._scope_stack[key]
+            errors.extend(errs)
+
+        if scope is None:
+            errors.extend(self._global_errors)
+
         return errors
+
+    def get_report(self, scope: JobScopeID | None = None) -> dict[JobScopeID, Any]:
+        if scope is None:
+            scope = next(iter(self._scope_stack.all_nodes), None)
+        if scope is None:
+            return {}
+        return {
+            scope: {
+                "status": self.get_status(scope),
+                "errors": self._scope_stack[scope],
+                "scopes": {
+                    child: self.get_report(child)[child] for child in self._scope_stack.children_of(scope, depth=1)
+                },
+            }
+        }
 
     def handle(self, event: JobEvent) -> None:
         if isinstance(event, JobStartScopeEvent):
@@ -68,7 +93,7 @@ class JobScopeStatuses(JobEventHandler):
         elif isinstance(event, JobSkipScopeEvent):
             self._skip_scope(event.skipped_scope)
         elif isinstance(event, JobErrorEvent):
-            self._error(event.error)
+            self._error(event.scope, event.error)
 
     def _start_scope(self, scope: JobScopeID) -> None:
         if self.get_status(scope) != JobScopeStatus.UNKNOWN:
@@ -85,13 +110,11 @@ class JobScopeStatuses(JobEventHandler):
     def _skip_scope(self, scope: JobScopeID) -> None:
         self._statuses[scope] = JobScopeStatus.SKIPPED
 
-    def _error(self, error: Exception | str) -> None:
-        scope: JobScopeID | None = self._scope_stack.get_scope()
-        path: tuple[JobScopeID, ...] = self._scope_stack.path_to(scope) if scope else tuple()
-        if path not in self._errors:
-            self._errors[path] = []
-        self._errors[path].append(error)
-        if scope:
+    def _error(self, scope: JobScopeID | None, error: Exception | str) -> None:
+        if scope is None:
+            self._global_errors.append(error)
+        else:
+            self._scope_stack[scope].append(error)
             # If we have a running scope mark it as failing
             self._statuses[scope] = JobScopeStatus.FAILING
 
@@ -245,6 +268,9 @@ class JobContextImpl(JobContext):
     @property
     def events(self) -> JobStatus:
         return self._status
+
+    def get_report(self, scope: JobScopeID | None = None) -> dict[JobScopeID, Any]:
+        return self._scope_statuses.get_report(scope)
 
     def get_scope_status(self, scope: JobScopeID) -> JobScopeStatus:
         return self._scope_statuses.get_status(scope)

--- a/src/rkojob/events.py
+++ b/src/rkojob/events.py
@@ -7,7 +7,6 @@ from typing import Iterable, cast
 
 from rkojob import (
     JobContext,
-    JobContextID,
     JobEvent,
     JobEventDispatcher,
     JobEventHandler,
@@ -21,7 +20,7 @@ from rkojob import (
 class JobStartScopeEvent(JobEvent):
     type = "start_scope"
 
-    def __init__(self, context: JobContextID, scope: JobScopeID | None, started_scope: JobScopeID) -> None:
+    def __init__(self, context: JobContext, scope: JobScopeID | None, started_scope: JobScopeID) -> None:
         super().__init__(context, scope, started_scope=started_scope)
 
     @property
@@ -32,7 +31,7 @@ class JobStartScopeEvent(JobEvent):
 class JobFinishScopeEvent(JobEvent):
     type = "finish_scope"
 
-    def __init__(self, context: JobContextID, scope: JobScopeID | None, finished_scope: JobScopeID) -> None:
+    def __init__(self, context: JobContext, scope: JobScopeID | None, finished_scope: JobScopeID) -> None:
         super().__init__(context, scope, finished_scope=finished_scope)
 
     @property
@@ -43,7 +42,7 @@ class JobFinishScopeEvent(JobEvent):
 class JobErrorEvent(JobEvent):
     type = "error"
 
-    def __init__(self, context: JobContextID, scope: JobScopeID | None, error: str | Exception) -> None:
+    def __init__(self, context: JobContext, scope: JobScopeID | None, error: str | Exception) -> None:
         super().__init__(context, scope, error=error)
 
     @property
@@ -55,7 +54,7 @@ class JobSkipScopeEvent(JobEvent):
     type = "skip_scope"
 
     def __init__(
-        self, context: JobContextID, scope: JobScopeID | None, skipped_scope: JobScopeID, reason: str | None = None
+        self, context: JobContext, scope: JobScopeID | None, skipped_scope: JobScopeID, reason: str | None = None
     ) -> None:
         super().__init__(context, scope, skipped_scope=skipped_scope, reason=reason)
 
@@ -71,7 +70,7 @@ class JobSkipScopeEvent(JobEvent):
 class JobStartSectionEvent(JobEvent):
     type = "start_section"
 
-    def __init__(self, context: JobContextID, scope: JobScopeID, section: str) -> None:
+    def __init__(self, context: JobContext, scope: JobScopeID, section: str) -> None:
         super().__init__(context, scope, section=section)
 
     @property
@@ -82,7 +81,7 @@ class JobStartSectionEvent(JobEvent):
 class JobFinishSectionEvent(JobEvent):
     type = "finish_section"
 
-    def __init__(self, context: JobContextID, scope: JobScopeID, section: str) -> None:
+    def __init__(self, context: JobContext, scope: JobScopeID, section: str) -> None:
         super().__init__(context, scope, section=section)
 
     @property
@@ -93,7 +92,7 @@ class JobFinishSectionEvent(JobEvent):
 class JobStartItemEvent(JobEvent):
     type = "start_item"
 
-    def __init__(self, context: JobContextID, scope: JobScopeID, item: str) -> None:
+    def __init__(self, context: JobContext, scope: JobScopeID, item: str) -> None:
         super().__init__(context, scope, item=item)
 
     @property
@@ -104,7 +103,7 @@ class JobStartItemEvent(JobEvent):
 class JobFinishItemEvent(JobEvent):
     type = "finish_item"
 
-    def __init__(self, context: JobContextID, scope: JobScopeID, outcome: str) -> None:
+    def __init__(self, context: JobContext, scope: JobScopeID, outcome: str) -> None:
         super().__init__(context, scope, outcome=outcome)
 
     @property
@@ -115,7 +114,7 @@ class JobFinishItemEvent(JobEvent):
 class JobWarningEvent(JobEvent):
     type = "warning"
 
-    def __init__(self, context: JobContextID, scope: JobScopeID, warning: str | Exception) -> None:
+    def __init__(self, context: JobContext, scope: JobScopeID, warning: str | Exception) -> None:
         super().__init__(context, scope, warning=warning)
 
     @property
@@ -126,7 +125,7 @@ class JobWarningEvent(JobEvent):
 class JobInfoEvent(JobEvent):
     type = "info"
 
-    def __init__(self, context: JobContextID, scope: JobScopeID, message: str) -> None:
+    def __init__(self, context: JobContext, scope: JobScopeID, message: str) -> None:
         super().__init__(context, scope, message=message)
 
     @property
@@ -137,7 +136,7 @@ class JobInfoEvent(JobEvent):
 class JobDetailEvent(JobEvent):
     type = "detail"
 
-    def __init__(self, context: JobContextID, scope: JobScopeID, message: str) -> None:
+    def __init__(self, context: JobContext, scope: JobScopeID, message: str) -> None:
         super().__init__(context, scope, message=message)
 
     @property
@@ -149,7 +148,7 @@ class JobOutputEvent(JobEvent):
     type = "output"
 
     def __init__(
-        self, context: JobContextID, scope: JobScopeID, output: str | Iterable[str], label: str | None = None
+        self, context: JobContext, scope: JobScopeID, output: str | Iterable[str], label: str | None = None
     ) -> None:
         super().__init__(context, scope, output=output, label=label or "output")
 
@@ -175,46 +174,46 @@ class JobStatusImpl(JobStatus):
         self._handler.handle(event)
 
     def start_scope(self, scope: JobScopeID) -> None:
-        self.handle(JobStartScopeEvent(self._context.id, self._context.get_scope(), started_scope=scope))
+        self.handle(JobStartScopeEvent(self._context, self._context.get_scope(), started_scope=scope))
 
     def finish_scope(self, scope: JobScopeID | None = None) -> None:
         if scope is None:
             scope = self._context.scope
         self.handle(
-            JobFinishScopeEvent(self._context.id, self._context.get_scope(scope, generation=1), finished_scope=scope)
+            JobFinishScopeEvent(self._context, self._context.get_scope(scope, generation=1), finished_scope=scope)
         )
 
     def skip_scope(self, scope: JobScopeID, reason: str | None = None) -> None:
-        self.handle(JobSkipScopeEvent(self._context.id, self._context.get_scope(), skipped_scope=scope, reason=reason))
+        self.handle(JobSkipScopeEvent(self._context, self._context.get_scope(), skipped_scope=scope, reason=reason))
 
     def start_section(self, section: str) -> None:
-        self.handle(JobStartSectionEvent(self._context.id, self._context.scope, section=section))
+        self.handle(JobStartSectionEvent(self._context, self._context.scope, section=section))
 
     def finish_section(self, section: str) -> None:
-        self.handle(JobFinishSectionEvent(self._context.id, self._context.scope, section=section))
+        self.handle(JobFinishSectionEvent(self._context, self._context.scope, section=section))
 
     def start_item(self, item: str) -> None:
-        self.handle(JobStartItemEvent(self._context.id, self._context.scope, item=item))
+        self.handle(JobStartItemEvent(self._context, self._context.scope, item=item))
 
     def finish_item(self, outcome: str = "done.", error: str | Exception | None = None) -> None:
         if error:
             self.error(error)
-        self.handle(JobFinishItemEvent(self._context.id, self._context.scope, outcome=outcome))
+        self.handle(JobFinishItemEvent(self._context, self._context.scope, outcome=outcome))
 
     def info(self, message: str) -> None:
-        self.handle(JobInfoEvent(self._context.id, self._context.scope, message=message))
+        self.handle(JobInfoEvent(self._context, self._context.scope, message=message))
 
     def detail(self, message: str) -> None:
-        self.handle(JobDetailEvent(self._context.id, self._context.scope, message=message))
+        self.handle(JobDetailEvent(self._context, self._context.scope, message=message))
 
     def warning(self, warning: str | Exception) -> None:
-        self.handle(JobWarningEvent(self._context.id, self._context.scope, warning=warning))
+        self.handle(JobWarningEvent(self._context, self._context.scope, warning=warning))
 
     def error(self, error: str | Exception) -> None:
-        self.handle(JobErrorEvent(self._context.id, self._context.scope, error=error))
+        self.handle(JobErrorEvent(self._context, self._context.scope, error=error))
 
     def output(self, output: str | Iterable[str], label: str | None = None) -> None:
-        self.handle(JobOutputEvent(self._context.id, self._context.scope, output=output, label=label))
+        self.handle(JobOutputEvent(self._context, self._context.scope, output=output, label=label))
 
 
 class JobDirectEventDispatcher(JobEventDispatcher):

--- a/src/rkojob/job.py
+++ b/src/rkojob/job.py
@@ -14,6 +14,7 @@ from rkojob import (
     JobCallable,
     JobConditionalType,
     JobContext,
+    JobIdType,
     JobScopeID,
     JobScopeType,
     create_scope_id,
@@ -33,10 +34,10 @@ class JobScopes(Enum):
 
 
 class JobScopeIDMixin(JobScopeID):
-    _id: str
+    _id: JobIdType
 
     @property
-    def id(self) -> str:
+    def id(self) -> JobIdType:
         return self._id
 
     def __eq__(self, other: object) -> bool:
@@ -62,7 +63,7 @@ class JobStep(JobScopeIDMixin, Generic[A]):
         action: A | None = None,
         run_if: JobConditionalType | None = None,
         skip_if: JobConditionalType | None = None,
-        id: str | None = None,
+        id: JobIdType | None = None,
     ) -> None:
         self._name: str = name
 
@@ -118,12 +119,12 @@ class JobStage(JobScopeIDMixin):
     Class representing a job stage that consists of one or more steps.
     """
 
-    def __init__(self, name: str, steps: list[JobStep] | None = None, id: str | None = None) -> None:
+    def __init__(self, name: str, steps: list[JobStep] | None = None, id: JobIdType | None = None) -> None:
         self._name: str = name
         if steps is None:
             steps = []
         self.steps: list[JobStep] = steps
-        self._id: str = id or create_scope_id()
+        self._id: JobIdType = id or create_scope_id()
 
     @property
     def name(self) -> str:
@@ -149,12 +150,12 @@ class Job(JobScopeIDMixin):
     Class representing a job that consists of one or more stages.
     """
 
-    def __init__(self, name: str, stages: list[JobStage] | None = None, id: str | None = None) -> None:
+    def __init__(self, name: str, stages: list[JobStage] | None = None, id: JobIdType | None = None) -> None:
         self._name: str = name
         if stages is None:
             stages = []
         self.stages: list[JobStage] = stages
-        self._id: str = id or create_scope_id()
+        self._id: JobIdType = id or create_scope_id()
 
     @property
     def name(self) -> str:
@@ -182,7 +183,7 @@ class JobStepBuilder(JobScopeIDMixin):
         self.teardown: Delegate[[JobContext], None] = Delegate(continue_on_error=True)
         self.run_if: JobConditionalType | None = None
         self.skip_if: JobConditionalType | None = None
-        self._id: str = create_scope_id()
+        self._id: JobIdType = create_scope_id()
         self.builds_type: JobScopeType = JobScopes.STEP
 
     def build(self) -> JobStep:
@@ -205,7 +206,7 @@ class JobStageBuilder(JobScopeIDMixin):
         self._name: str = name
         self._steps: list[JobStep] = []
         self.teardown: Delegate[[JobContext], None] = Delegate(continue_on_error=True)
-        self._id: str = create_scope_id()
+        self._id: JobIdType = create_scope_id()
         self.builds_type: JobScopeType = JobScopes.STAGE
 
     @contextmanager
@@ -228,7 +229,7 @@ class JobBuilder(JobScopeIDMixin, AbstractContextManager):
         self._name: str = name
         self._stages: list[JobStage] = []
         self.teardown: Delegate[[JobContext], None] = Delegate(continue_on_error=True)
-        self._id: str = create_scope_id()
+        self._id: JobIdType = create_scope_id()
         self.builds_type: JobScopeType = JobScopes.JOB
 
     def __exit__(self, exc_type, exc_value, traceback, /):

--- a/src/rkojob/runner.py
+++ b/src/rkojob/runner.py
@@ -5,6 +5,8 @@
 
 from typing import Any, cast
 
+import yaml
+
 from rkojob import (
     JobActionScope,
     JobConditionalScope,
@@ -14,6 +16,7 @@ from rkojob import (
     JobException,
     JobGroupScope,
     JobScope,
+    JobScopeID,
     JobTeardownScope,
     job_failing,
     job_never,
@@ -35,9 +38,42 @@ class JobRunnerImpl:
         :param scope: The scope to run.
         """
         self._run_scope(context, scope)
-        errors: list[Exception] = context.get_errors()
-        if errors:
-            raise JobException("\n".join([str(e) for e in errors]))
+        self._check_for_errors(context)
+
+    def _check_for_errors(self, context: JobContext):
+        report: dict[JobScopeID, Any] = context.get_report()
+
+        if self._has_errors(report):
+            errors = self._gather_errors(report)
+            report_str: str = yaml.dump(errors)
+            raise JobException(report_str)
+
+    def _has_errors(self, report: dict[JobScopeID, Any]) -> bool:
+        for scope in report:
+            if report[scope].get("errors"):
+                return True
+            if self._has_errors(report[scope].get("scopes")):
+                return True
+        return False
+
+    def _gather_errors(self, report: dict[JobScopeID, Any]) -> dict[str, Any] | None:
+        if not self._has_errors(report):
+            return None
+        errors: dict[str, Any] = {}
+        for scope in report:
+            scope_str: str = str(scope)
+            scope_report = report[scope]
+
+            scope_errors: list[str | Exception] = scope_report.get("errors")
+            if scope_errors:
+                errors[scope_str] = {"errors": [str(error) for error in scope_errors]}
+
+            child_errors: dict[str, Any] | None = self._gather_errors(scope_report.get("scopes", {}))
+            if child_errors:
+                if scope_str not in errors:
+                    errors[scope_str] = {}
+                errors[scope_str].update(**child_errors)
+        return errors
 
     def _run_scope(self, context: JobContext, scope: JobScope) -> None:
         # Run and then teardown a scope.

--- a/tests/test_rkojob/test_context.py
+++ b/tests/test_rkojob/test_context.py
@@ -27,6 +27,7 @@ from rkojob.events import (
     JobStartItemEvent,
     JobStartScopeEvent,
 )
+from rkojob.job import JobScopeIDMixin
 
 
 class TestJobScopeStatuses(TestCase):
@@ -96,14 +97,22 @@ class TestJobScopeStatuses(TestCase):
         self.assertEqual(JobScopeStatus.FAILED, sut.get_status(mock_scope_1))
 
 
-class StubScope:
+class StubScopeID(JobScopeIDMixin):
+    def __init__(self, id):
+        self._id = id
+
+    def __repr__(self):
+        return repr(self.id)
+
+
+class StubScope(JobScopeIDMixin):
     def __init__(self, name, type, teardown=None, id=None):
         self.name = name
         self.type = type
         self.teardown = Delegate[[JobContext], None](continue_on_error=True, reverse=True)
         if teardown:
             self.teardown += teardown
-        self.id = id or create_scope_id()
+        self._id = id or create_scope_id()
 
     def __str__(self):
         return f"{self.type} {self.name}"
@@ -151,10 +160,6 @@ class TestJobContextImpl(TestCase):
             self.assertIs(stub_scope_1, sut.scope)
 
     def test_get_scope(self) -> None:
-        class StubScopeID:
-            def __init__(self, id):
-                self.id = id
-
         sut = JobContextImpl()
 
         self.assertIsNone(sut.get_scope())

--- a/tests/test_rkojob/test_context.py
+++ b/tests/test_rkojob/test_context.py
@@ -96,6 +96,100 @@ class TestJobScopeStatuses(TestCase):
         sut.handle(JobFinishScopeEvent(mock_context, None, finished_scope=mock_scope_1))
         self.assertEqual(JobScopeStatus.FAILED, sut.get_status(mock_scope_1))
 
+    def test_get_errors(self) -> None:
+        mock_context = MagicMock()
+        mock_scope_1 = MagicMock()
+        mock_scope_2 = MagicMock()
+        mock_scope_3 = MagicMock()
+
+        sut = JobScopeStatuses()
+        sut.handle(JobStartScopeEvent(mock_context, None, started_scope=mock_scope_1))
+        sut.handle(JobStartScopeEvent(mock_context, mock_scope_1, started_scope=mock_scope_2))
+        sut.handle(JobStartScopeEvent(mock_context, mock_scope_2, started_scope=mock_scope_3))
+
+        self.assertEqual([], sut.get_errors(mock_scope_1))
+        self.assertEqual([], sut.get_errors(mock_scope_2))
+        self.assertEqual([], sut.get_errors(mock_scope_3))
+        self.assertEqual([], sut.get_errors(None))
+
+        sut.handle(JobErrorEvent(mock_context, mock_scope_3, "error"))
+        self.assertEqual(["error"], sut.get_errors(mock_scope_1))
+        self.assertEqual(["error"], sut.get_errors(mock_scope_2))
+        self.assertEqual(["error"], sut.get_errors(mock_scope_3))
+        self.assertEqual(["error"], sut.get_errors(None))
+
+        sut.handle(JobFinishScopeEvent(mock_context, mock_scope_2, finished_scope=mock_scope_3))
+
+        sut.handle(JobErrorEvent(mock_context, mock_scope_2, "error2"))
+        self.assertEqual(["error", "error2"], sut.get_errors(mock_scope_1))
+        self.assertEqual(["error", "error2"], sut.get_errors(mock_scope_2))
+        self.assertEqual(["error"], sut.get_errors(mock_scope_3))
+        self.assertEqual(["error", "error2"], sut.get_errors(None))
+
+        sut.handle(JobFinishScopeEvent(mock_context, mock_scope_1, finished_scope=mock_scope_2))
+
+        sut.handle(JobErrorEvent(mock_context, mock_scope_1, "error3"))
+        self.assertEqual(["error", "error2", "error3"], sut.get_errors(mock_scope_1))
+        self.assertEqual(["error", "error2"], sut.get_errors(mock_scope_2))
+        self.assertEqual(["error"], sut.get_errors(mock_scope_3))
+        self.assertEqual(["error", "error2", "error3"], sut.get_errors(None))
+
+        sut.handle(JobFinishScopeEvent(mock_context, None, finished_scope=mock_scope_1))
+
+        sut.handle(JobErrorEvent(mock_context, None, "error4"))
+        self.assertEqual(["error", "error2", "error3"], sut.get_errors(mock_scope_1))
+        self.assertEqual(["error", "error2"], sut.get_errors(mock_scope_2))
+        self.assertEqual(["error"], sut.get_errors(mock_scope_3))
+        self.assertEqual(["error", "error2", "error3", "error4"], sut.get_errors(None))
+
+    def test_get_report(self) -> None:
+        mock_context = MagicMock()
+        stub_scope_1 = StubScopeID("scope-1")
+        stub_scope_2 = StubScopeID("scope-2")
+        stub_scope_3 = StubScopeID("scope-3")
+
+        sut = JobScopeStatuses()
+        sut.handle(JobStartScopeEvent(mock_context, None, started_scope=stub_scope_1))
+        sut.handle(JobStartScopeEvent(mock_context, stub_scope_1, started_scope=stub_scope_2))
+        sut.handle(JobStartScopeEvent(mock_context, stub_scope_2, started_scope=stub_scope_3))
+
+        sut.handle(JobErrorEvent(mock_context, stub_scope_3, "error"))
+
+        sut.handle(JobFinishScopeEvent(mock_context, stub_scope_2, finished_scope=stub_scope_3))
+
+        sut.handle(JobErrorEvent(mock_context, stub_scope_2, "error2"))
+
+        sut.handle(JobFinishScopeEvent(mock_context, stub_scope_1, finished_scope=stub_scope_2))
+
+        sut.handle(JobErrorEvent(mock_context, stub_scope_1, "error3"))
+
+        sut.handle(JobFinishScopeEvent(mock_context, None, finished_scope=stub_scope_1))
+
+        sut.handle(JobErrorEvent(mock_context, None, "error4"))
+
+        self.assertEqual(
+            {
+                stub_scope_1: {
+                    "status": JobScopeStatus.FAILED,
+                    "errors": ["error3"],
+                    "scopes": {
+                        stub_scope_2: {
+                            "status": JobScopeStatus.FAILED,
+                            "errors": ["error2"],
+                            "scopes": {
+                                stub_scope_3: {"status": JobScopeStatus.FAILED, "errors": ["error"], "scopes": {}}
+                            },
+                        }
+                    },
+                }
+            },
+            sut.get_report(),
+        )
+        self.assertEqual(
+            {stub_scope_3: {"status": JobScopeStatus.FAILED, "errors": ["error"], "scopes": {}}},
+            sut.get_report(stub_scope_3),
+        )
+
 
 class StubScopeID(JobScopeIDMixin):
     def __init__(self, id):
@@ -329,10 +423,14 @@ class TestJobContextImpl(TestCase):
 
                 sut.events.error(boz_error)
 
-        self.assertEqual([foo_error, bar_error, baz_error, boz_error, buz_error], sut.get_errors())
-        self.assertEqual([baz_error, boz_error, buz_error], sut.get_errors(stub_scope_1))
+        self.assertEqual([buz_error, baz_error, boz_error, foo_error, bar_error], sut.get_errors())
+        self.assertEqual([buz_error, baz_error, boz_error], sut.get_errors(stub_scope_1))
         self.assertEqual([buz_error], sut.get_errors(stub_scope_2))
 
     def test_values(self) -> None:
         sut = JobContextImpl()
         self.assertIsInstance(sut.values, Values)
+
+    def test_get_report(self) -> None:
+        sut = JobContextImpl()
+        self.assertEqual({}, sut.get_report())

--- a/tests/test_rkojob/test_events.py
+++ b/tests/test_rkojob/test_events.py
@@ -31,7 +31,7 @@ class StubContext:
         self._scopes = JobScopeStack()
 
     def handle(self, event):
-        if event.context == self.id:
+        if event.context.id == self.id:
             if isinstance(event, JobStartScopeEvent):
                 self._scopes.push(event.started_scope)
             elif isinstance(event, JobFinishScopeEvent):
@@ -114,9 +114,7 @@ class TestJobStatusImpl(TestCase):
         stub_context, mock_scope, mock_handler, sut = self._create_sut()
 
         sut.start_scope(mock_scope)
-        self.assertHandledEvent(
-            mock_handler.handle, JobStartScopeEvent, stub_context.id, None, started_scope=mock_scope
-        )
+        self.assertHandledEvent(mock_handler.handle, JobStartScopeEvent, stub_context, None, started_scope=mock_scope)
 
     def test_finish_scope(self) -> None:
         stub_context, mock_scope, mock_handler, sut = self._create_sut()
@@ -125,9 +123,7 @@ class TestJobStatusImpl(TestCase):
         mock_handler.reset_mock()
 
         sut.finish_scope(mock_scope)
-        self.assertHandledEvent(
-            mock_handler.handle, JobFinishScopeEvent, stub_context.id, None, finished_scope=mock_scope
-        )
+        self.assertHandledEvent(mock_handler.handle, JobFinishScopeEvent, stub_context, None, finished_scope=mock_scope)
 
     def test_finish_scope_no_scope(self) -> None:
         stub_context, mock_scope, mock_handler, sut = self._create_sut()
@@ -136,16 +132,14 @@ class TestJobStatusImpl(TestCase):
         mock_handler.reset_mock()
 
         sut.finish_scope()
-        self.assertHandledEvent(
-            mock_handler.handle, JobFinishScopeEvent, stub_context.id, None, finished_scope=mock_scope
-        )
+        self.assertHandledEvent(mock_handler.handle, JobFinishScopeEvent, stub_context, None, finished_scope=mock_scope)
 
     def test_skip_scope(self) -> None:
         stub_context, mock_scope, mock_handler, sut = self._create_sut()
 
         sut.skip_scope(mock_scope, "skipped")
         self.assertHandledEvent(
-            mock_handler.handle, JobSkipScopeEvent, stub_context.id, None, skipped_scope=mock_scope, reason="skipped"
+            mock_handler.handle, JobSkipScopeEvent, stub_context, None, skipped_scope=mock_scope, reason="skipped"
         )
 
     def test_start_section(self) -> None:
@@ -155,9 +149,7 @@ class TestJobStatusImpl(TestCase):
         mock_handler.reset_mock()
 
         sut.start_section("section")
-        self.assertHandledEvent(
-            mock_handler.handle, JobStartSectionEvent, stub_context.id, mock_scope, section="section"
-        )
+        self.assertHandledEvent(mock_handler.handle, JobStartSectionEvent, stub_context, mock_scope, section="section")
 
     def test_finish_section(self) -> None:
         stub_context, mock_scope, mock_handler, sut = self._create_sut()
@@ -166,9 +158,7 @@ class TestJobStatusImpl(TestCase):
         mock_handler.reset_mock()
 
         sut.finish_section("section")
-        self.assertHandledEvent(
-            mock_handler.handle, JobFinishSectionEvent, stub_context.id, mock_scope, section="section"
-        )
+        self.assertHandledEvent(mock_handler.handle, JobFinishSectionEvent, stub_context, mock_scope, section="section")
 
     def test_start_item(self) -> None:
         stub_context, mock_scope, mock_handler, sut = self._create_sut()
@@ -177,7 +167,7 @@ class TestJobStatusImpl(TestCase):
         mock_handler.reset_mock()
 
         sut.start_item("item")
-        self.assertHandledEvent(mock_handler.handle, JobStartItemEvent, stub_context.id, mock_scope, item="item")
+        self.assertHandledEvent(mock_handler.handle, JobStartItemEvent, stub_context, mock_scope, item="item")
 
     def test_finish_item(self) -> None:
         stub_context, mock_scope, mock_handler, sut = self._create_sut()
@@ -186,7 +176,7 @@ class TestJobStatusImpl(TestCase):
         mock_handler.reset_mock()
 
         sut.finish_item("ok")
-        self.assertHandledEvent(mock_handler.handle, JobFinishItemEvent, stub_context.id, mock_scope, outcome="ok")
+        self.assertHandledEvent(mock_handler.handle, JobFinishItemEvent, stub_context, mock_scope, outcome="ok")
 
     def test_finish_item_with_error(self) -> None:
         stub_context, mock_scope, mock_handler, sut = self._create_sut()
@@ -195,11 +185,9 @@ class TestJobStatusImpl(TestCase):
         mock_handler.reset_mock()
 
         sut.finish_item(outcome="fail", error="timeout")
+        self.assertHandledEvent(mock_handler.handle, JobErrorEvent, stub_context, mock_scope, error="timeout", index=0)
         self.assertHandledEvent(
-            mock_handler.handle, JobErrorEvent, stub_context.id, mock_scope, error="timeout", index=0
-        )
-        self.assertHandledEvent(
-            mock_handler.handle, JobFinishItemEvent, stub_context.id, mock_scope, outcome="fail", index=1
+            mock_handler.handle, JobFinishItemEvent, stub_context, mock_scope, outcome="fail", index=1
         )
 
     def test_info(self) -> None:
@@ -209,7 +197,7 @@ class TestJobStatusImpl(TestCase):
         mock_handler.reset_mock()
 
         sut.info("step done")
-        self.assertHandledEvent(mock_handler.handle, JobInfoEvent, stub_context.id, mock_scope, message="step done")
+        self.assertHandledEvent(mock_handler.handle, JobInfoEvent, stub_context, mock_scope, message="step done")
 
     def test_detail(self) -> None:
         stub_context, mock_scope, mock_handler, sut = self._create_sut()
@@ -218,7 +206,7 @@ class TestJobStatusImpl(TestCase):
         mock_handler.reset_mock()
 
         sut.detail("debug")
-        self.assertHandledEvent(mock_handler.handle, JobDetailEvent, stub_context.id, mock_scope, message="debug")
+        self.assertHandledEvent(mock_handler.handle, JobDetailEvent, stub_context, mock_scope, message="debug")
 
     def test_warning(self) -> None:
         stub_context, mock_scope, mock_handler, sut = self._create_sut()
@@ -227,7 +215,7 @@ class TestJobStatusImpl(TestCase):
         mock_handler.reset_mock()
 
         sut.warning("warning")
-        self.assertHandledEvent(mock_handler.handle, JobWarningEvent, stub_context.id, mock_scope, warning="warning")
+        self.assertHandledEvent(mock_handler.handle, JobWarningEvent, stub_context, mock_scope, warning="warning")
 
     def test_error(self) -> None:
         stub_context, mock_scope, mock_handler, sut = self._create_sut()
@@ -236,7 +224,7 @@ class TestJobStatusImpl(TestCase):
         mock_handler.reset_mock()
 
         sut.error("error")
-        self.assertHandledEvent(mock_handler.handle, JobErrorEvent, stub_context.id, mock_scope, error="error")
+        self.assertHandledEvent(mock_handler.handle, JobErrorEvent, stub_context, mock_scope, error="error")
 
     def test_output(self) -> None:
         stub_context, mock_scope, mock_handler, sut = self._create_sut()
@@ -248,7 +236,7 @@ class TestJobStatusImpl(TestCase):
         self.assertHandledEvent(
             mock_handler.handle,
             JobOutputEvent,
-            stub_context.id,
+            stub_context,
             mock_scope,
             output=["line 1", "line 2"],
             label="stdout",
@@ -261,10 +249,10 @@ class TestJobStatusImpl(TestCase):
             pass
 
         self.assertHandledEvent(
-            mock_handler.handle, JobStartScopeEvent, stub_context.id, None, started_scope=mock_scope, index=0
+            mock_handler.handle, JobStartScopeEvent, stub_context, None, started_scope=mock_scope, index=0
         )
         self.assertHandledEvent(
-            mock_handler.handle, JobFinishScopeEvent, stub_context.id, None, finished_scope=mock_scope, index=1
+            mock_handler.handle, JobFinishScopeEvent, stub_context, None, finished_scope=mock_scope, index=1
         )
 
     def test_scope_error(self) -> None:
@@ -277,11 +265,11 @@ class TestJobStatusImpl(TestCase):
                 raise error
 
         self.assertHandledEvent(
-            mock_handler.handle, JobStartScopeEvent, stub_context.id, None, started_scope=mock_scope, index=0
+            mock_handler.handle, JobStartScopeEvent, stub_context, None, started_scope=mock_scope, index=0
         )
-        self.assertHandledEvent(mock_handler.handle, JobErrorEvent, stub_context.id, mock_scope, error=error, index=1)
+        self.assertHandledEvent(mock_handler.handle, JobErrorEvent, stub_context, mock_scope, error=error, index=1)
         self.assertHandledEvent(
-            mock_handler.handle, JobFinishScopeEvent, stub_context.id, None, finished_scope=mock_scope, index=2
+            mock_handler.handle, JobFinishScopeEvent, stub_context, None, finished_scope=mock_scope, index=2
         )
 
     def test_section(self) -> None:
@@ -292,16 +280,16 @@ class TestJobStatusImpl(TestCase):
                 pass
 
         self.assertHandledEvent(
-            mock_handler.handle, JobStartScopeEvent, stub_context.id, None, started_scope=mock_scope, index=0
+            mock_handler.handle, JobStartScopeEvent, stub_context, None, started_scope=mock_scope, index=0
         )
         self.assertHandledEvent(
-            mock_handler.handle, JobStartSectionEvent, stub_context.id, mock_scope, section="section", index=1
+            mock_handler.handle, JobStartSectionEvent, stub_context, mock_scope, section="section", index=1
         )
         self.assertHandledEvent(
-            mock_handler.handle, JobFinishSectionEvent, stub_context.id, mock_scope, section="section", index=2
+            mock_handler.handle, JobFinishSectionEvent, stub_context, mock_scope, section="section", index=2
         )
         self.assertHandledEvent(
-            mock_handler.handle, JobFinishScopeEvent, stub_context.id, None, finished_scope=mock_scope, index=3
+            mock_handler.handle, JobFinishScopeEvent, stub_context, None, finished_scope=mock_scope, index=3
         )
 
     def test_section_error(self) -> None:
@@ -315,18 +303,18 @@ class TestJobStatusImpl(TestCase):
                     raise error
 
         self.assertHandledEvent(
-            mock_handler.handle, JobStartScopeEvent, stub_context.id, None, started_scope=mock_scope, index=0
+            mock_handler.handle, JobStartScopeEvent, stub_context, None, started_scope=mock_scope, index=0
         )
         self.assertHandledEvent(
-            mock_handler.handle, JobStartSectionEvent, stub_context.id, mock_scope, section="section", index=1
+            mock_handler.handle, JobStartSectionEvent, stub_context, mock_scope, section="section", index=1
         )
-        self.assertHandledEvent(mock_handler.handle, JobErrorEvent, stub_context.id, mock_scope, error=error, index=2)
+        self.assertHandledEvent(mock_handler.handle, JobErrorEvent, stub_context, mock_scope, error=error, index=2)
         self.assertHandledEvent(
-            mock_handler.handle, JobFinishSectionEvent, stub_context.id, mock_scope, section="section", index=3
+            mock_handler.handle, JobFinishSectionEvent, stub_context, mock_scope, section="section", index=3
         )
-        self.assertHandledEvent(mock_handler.handle, JobErrorEvent, stub_context.id, mock_scope, error=error, index=4)
+        self.assertHandledEvent(mock_handler.handle, JobErrorEvent, stub_context, mock_scope, error=error, index=4)
         self.assertHandledEvent(
-            mock_handler.handle, JobFinishScopeEvent, stub_context.id, None, finished_scope=mock_scope, index=5
+            mock_handler.handle, JobFinishScopeEvent, stub_context, None, finished_scope=mock_scope, index=5
         )
 
     def test_item(self) -> None:
@@ -337,16 +325,14 @@ class TestJobStatusImpl(TestCase):
                 pass
 
         self.assertHandledEvent(
-            mock_handler.handle, JobStartScopeEvent, stub_context.id, None, started_scope=mock_scope, index=0
+            mock_handler.handle, JobStartScopeEvent, stub_context, None, started_scope=mock_scope, index=0
+        )
+        self.assertHandledEvent(mock_handler.handle, JobStartItemEvent, stub_context, mock_scope, item="item", index=1)
+        self.assertHandledEvent(
+            mock_handler.handle, JobFinishItemEvent, stub_context, mock_scope, outcome="done.", index=2
         )
         self.assertHandledEvent(
-            mock_handler.handle, JobStartItemEvent, stub_context.id, mock_scope, item="item", index=1
-        )
-        self.assertHandledEvent(
-            mock_handler.handle, JobFinishItemEvent, stub_context.id, mock_scope, outcome="done.", index=2
-        )
-        self.assertHandledEvent(
-            mock_handler.handle, JobFinishScopeEvent, stub_context.id, None, finished_scope=mock_scope, index=3
+            mock_handler.handle, JobFinishScopeEvent, stub_context, None, finished_scope=mock_scope, index=3
         )
 
     def test_item_error(self) -> None:
@@ -360,22 +346,18 @@ class TestJobStatusImpl(TestCase):
                     raise error
 
             self.assertHandledEvent(
-                mock_handler.handle, JobStartScopeEvent, stub_context.id, None, started_scope=mock_scope, index=0
+                mock_handler.handle, JobStartScopeEvent, stub_context, None, started_scope=mock_scope, index=0
             )
             self.assertHandledEvent(
-                mock_handler.handle, JobStartItemEvent, stub_context.id, mock_scope, item="item", index=1
+                mock_handler.handle, JobStartItemEvent, stub_context, mock_scope, item="item", index=1
             )
+            self.assertHandledEvent(mock_handler.handle, JobErrorEvent, stub_context, mock_scope, error=error, index=2)
             self.assertHandledEvent(
-                mock_handler.handle, JobErrorEvent, stub_context.id, mock_scope, error=error, index=2
+                mock_handler.handle, JobFinishItemEvent, stub_context, mock_scope, outcome="done.", index=3
             )
+            self.assertHandledEvent(mock_handler.handle, JobErrorEvent, stub_context, mock_scope, error=error, index=4)
             self.assertHandledEvent(
-                mock_handler.handle, JobFinishItemEvent, stub_context.id, mock_scope, outcome="done.", index=3
-            )
-            self.assertHandledEvent(
-                mock_handler.handle, JobErrorEvent, stub_context.id, mock_scope, error=error, index=4
-            )
-            self.assertHandledEvent(
-                mock_handler.handle, JobFinishScopeEvent, stub_context.id, None, finished_scope=mock_scope, index=5
+                mock_handler.handle, JobFinishScopeEvent, stub_context, None, finished_scope=mock_scope, index=5
             )
 
 

--- a/tests/test_rkojob/test_rkojob.py
+++ b/tests/test_rkojob/test_rkojob.py
@@ -119,6 +119,50 @@ class TestJobScopeStack(TestCase):
         self.assertEqual((scope1, scope2), sut.path_to(scope2))
         self.assertEqual((scope1, scope2, scope3), sut.path_to(scope3))
 
+    def test_children_of(self) -> None:
+        sut: JobScopeStack[JobScopeID, str] = JobScopeStack()
+        scope1 = StubScope("scope1", "type")
+        scope2 = StubScope("scope2", "type")
+        scope3 = StubScope("scope3", "type")
+        scope4 = StubScope("scope4", "type")
+        scope5 = StubScope("scope5", "type")
+
+        sut.push(scope1, "scope1")
+        sut.push(scope2, "scope2")
+        sut.push(scope3, "scope3")
+        sut.pop()
+        sut.push(scope4, "scope4")
+        sut.pop()
+        sut.pop()
+        sut.push(scope5, "scope5")
+
+        self.assertEqual(["scope2", "scope3", "scope4", "scope5"], [sut[child] for child in sut.children_of(scope1)])
+        self.assertEqual(["scope2", "scope5"], [sut[child] for child in sut.children_of(scope1, depth=1)])
+        self.assertEqual(["scope3", "scope4"], [sut[child] for child in sut.children_of(scope2)])
+        self.assertEqual(["scope3", "scope4"], [sut[child] for child in sut.children_of(scope2, depth=1)])
+        self.assertEqual([], [sut[child] for child in sut.children_of(scope3)])
+        self.assertEqual([], [sut[child] for child in sut.children_of(scope4)])
+        self.assertEqual([], [sut[child] for child in sut.children_of(scope5)])
+
+    def test_all_nodes(self) -> None:
+        sut: JobScopeStack[JobScopeID, str] = JobScopeStack()
+        scope1 = StubScope("scope1", "type")
+        scope2 = StubScope("scope2", "type")
+        scope3 = StubScope("scope3", "type")
+        scope4 = StubScope("scope4", "type")
+        scope5 = StubScope("scope5", "type")
+
+        sut.push(scope1, "scope1")
+        sut.push(scope2, "scope2")
+        sut.push(scope3, "scope3")
+        sut.pop()
+        sut.push(scope4, "scope4")
+        sut.pop()
+        sut.pop()
+        sut.push(scope5, "scope5")
+
+        self.assertEqual([scope1, scope2, scope3, scope4, scope5], [*sut.all_nodes])
+
     def test_push_pop_peek(self) -> None:
         sut: JobScopeStack[JobScopeID, str] = JobScopeStack()
 

--- a/tests/test_rkojob/test_runner.py
+++ b/tests/test_rkojob/test_runner.py
@@ -100,9 +100,8 @@ class TestJobRunnerImpl(TestCase):
         # This teardown should run
         job.teardown += self._teardown("job", side_effects)
 
-        with self.assertRaises(Exception) as e:
+        with self.assertRaises(Exception):
             JobRunnerImpl().run(JobContextFactory.create(), job)
-        self.assertEqual("Action failed: job->stage1->step1.2", str(e.exception))
 
         self.assertEqual(
             ["Action: job->stage1->step1.1", "Teardown job: step1.1", "Teardown job: job"],
@@ -338,9 +337,8 @@ class TestJobRunnerImpl(TestCase):
         side_effects.clear()
         job.scopes[0].scopes[0].action = self._action(side_effects, fail=True)
 
-        with self.assertRaises(Exception) as e:
+        with self.assertRaises(Exception):
             JobRunnerImpl().run(JobContextFactory.create(), job)
-        self.assertEqual("Action failed: job->stage1->step1.1", str(e.exception))
 
         self.assertEqual(
             [
@@ -400,9 +398,8 @@ class TestJobRunnerImpl(TestCase):
         side_effects: list[str] = []
         job = self._create_job(side_effects)
         job.scopes[0].scopes[1].action = self._action(side_effects, fail=True)
-        with self.assertRaises(Exception) as e:
+        with self.assertRaises(Exception):
             JobRunnerImpl().run(JobContextFactory.create(), job)
-        self.assertEqual("Action failed: job->stage1->step1.2", str(e.exception))
 
         self.assertEqual(
             [
@@ -443,9 +440,8 @@ class TestJobRunnerImpl(TestCase):
         job = self._create_job(side_effects)
         job.scopes[0].scopes[1].action = self._action(side_effects, fail=True)
         job.scopes[1].scopes[0].skip_if = scope_succeeding(job.scopes[0])
-        with self.assertRaises(Exception) as e:
+        with self.assertRaises(Exception):
             JobRunnerImpl().run(JobContextFactory.create(), job)
-        self.assertEqual("Action failed: job->stage1->step1.2", str(e.exception))
 
         self.assertEqual(
             [


### PR DESCRIPTION
A few minor follow-up changes after recent event-driven changes:

- Include `JobContext` instead of `JobContextID` to `JobEvent`
- Augment `JobScopeStack` to allow bi-directional traversal and replace the `_known_scopes` map.
- Improve output of errors at end of job run.
