### PR TITLE
Add with_env() and in_dir() to ShellAction.

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,8 +223,11 @@ Built-in condition helpers:
 - `job_never`: Always returns `False`
 - `job_failing`: Returns `True` if the job has any recorded errors
 - `job_succeeding`: Returns `True` if the job has no errors
+- `scope_ran(scope)`: True if the given scope has run
 - `scope_failing(scope)`: True if the given scope has any errors
 - `scope_succeeding(scope)`: True if the given scope has no errors
+- `scope_status(scope, status...)`: True if the given scope status
+  matches one of the provided statuses
 
 **Example:**
 

--- a/src/rkojob/actions.py
+++ b/src/rkojob/actions.py
@@ -2,6 +2,8 @@
 #
 # This work is licensed under the terms of the MIT license.
 # For a copy, see <https://opensource.org/licenses/MIT>.
+from __future__ import annotations
+
 import shlex
 from enum import Enum, auto
 from os import PathLike
@@ -100,6 +102,28 @@ class ShellAction(JobAction):
                         context.events.output(result.stderr, label="stderr")
                 else:
                     unassign_value(self.result)
+
+    def with_env(self, **kwargs) -> ShellAction:
+        """
+        Update default environment variables set when executing the shell command.
+
+        :param kwargs: Additional environment variables to set.
+        :returns: This instance for call chaining.
+        """
+        env: dict[str, Any] = self._kwargs.get("env", {})
+        env.update(**kwargs)
+        self._kwargs["env"] = env
+        return self
+
+    def in_dir(self, cwd: str | PathLike) -> ShellAction:
+        """
+        Set the current working directory that the shell command will be executed in.
+
+        :param cwd: The directory to execute the shell command.
+        :returns: This instance for call chaining.
+        """
+        self._kwargs["cwd"] = cwd
+        return self
 
 
 class ToolActionBuilder:

--- a/src/rkojob/util.py
+++ b/src/rkojob/util.py
@@ -10,7 +10,7 @@ import re
 import subprocess
 import sys
 from os import PathLike
-from typing import IO, Any, Iterable, TypeVar
+from typing import IO, Any, Iterable, Type, TypeVar
 
 
 class ShellResult:
@@ -224,14 +224,18 @@ class ToolBuilder:
 
     """
 
-    def __init__(self, *commands: str, shell: Shell | None = None):
+    def __init__(self, *commands: str, default_runner_type: Type[ToolRunner] | None = None, shell: Shell | None = None):
         """
         :param commands: Optional initial command parts.
-        :param kwargs: Optional keyword args to pass to ``Shell()``
+        :param default_runner_type: Optional default `ToolRunner` type used to
+         prepare and execute the tool.
         :param shell: Optional `Shell` instance to use instead of default.
         """
         self._commands: list[str] = list(commands)
         self._shell: Shell | None = shell
+
+        self._builder_type: Type[ToolBuilder] = type(self)
+        self._runner_type: Type[ToolRunner] = default_runner_type or ToolRunner
 
     def prepare(self, *args, runner_type: type[ToolRunner] | None = None, **kwargs) -> ToolRunner:
         """
@@ -241,11 +245,12 @@ class ToolBuilder:
         :param kwargs: Additional kwargs to be passed into the command.
         """
         if runner_type is None:
-            runner_type = ToolRunner
+            runner_type = self._runner_type
+
         return runner_type(self._commands, *args, **kwargs, shell=self._shell)
 
     def __getattr__(self, name: str):
-        return ToolBuilder(*self._commands, name, shell=self._shell)
+        return self._builder_type(*self._commands, name, shell=self._shell)
 
     def __call__(self, *args: Any, **kwargs) -> ShellResult:
         runner: ToolRunner = self.prepare(*args, **kwargs)

--- a/tests/test_rkojob/test_actions.py
+++ b/tests/test_rkojob/test_actions.py
@@ -38,6 +38,26 @@ class TestShellAction(TestCase):
         self.assertEqual(shell_result, sut.result.get())
 
     @patch("rkojob.actions.Shell")
+    def test_with_env(self, mock_shell_cls):
+        context = self.make_context()
+
+        sut = ShellAction("echo", "ok")
+        sut.with_env(VAR="value")
+        sut.action(context)
+        mock_shell_cls.assert_called_once_with(env={"VAR": "value"})
+        mock_shell_cls().assert_called_once_with("echo", "ok")
+
+    @patch("rkojob.actions.Shell")
+    def test_in_dir(self, mock_shell_cls):
+        context = self.make_context()
+
+        sut = ShellAction("echo", "ok")
+        sut.in_dir("/some/path")
+        sut.action(context)
+        mock_shell_cls.assert_called_once_with(cwd="/some/path")
+        mock_shell_cls().assert_called_once_with("echo", "ok")
+
+    @patch("rkojob.actions.Shell")
     def test_shell_exception(self, mock_shell_cls):
         result = ShellResult(stdout="", stderr="boom", return_code=99)
         exception = ShellException(result=result)

--- a/tests/test_rkojob/test_util.py
+++ b/tests/test_rkojob/test_util.py
@@ -195,6 +195,19 @@ class TestToolBuilder(TestCase):
             "command", "sub-command", "arg1", "--arg2", "value2", "--arg3", "value3", "--arg-4", 1234
         )
 
+    def test_sub_class(self) -> None:
+        class SubClassRunner(ToolRunner):
+            pass
+
+        class SubClassBuilder(ToolBuilder):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, default_runner_type=SubClassRunner, **kwargs)
+
+        sut = SubClassBuilder("tool").sub_command
+        self.assertIsInstance(sut, SubClassBuilder)
+        runner = sut.prepare(arg="value")
+        self.assertIsInstance(runner, SubClassRunner)
+
 
 class TestToolRunner(TestCase):
     def test_call(self) -> None:


### PR DESCRIPTION
Update `ShellAction` to add `.with_env()` and `.in_dir()` methods similar to `ToolRunner`:

```python
go: ToolActionBuilder = ToolActionBuilder("go")
install_action: ShellAction = go.install("some-package").with_env(GOPATH="/custom/path/to/go")
```