### PR TITLE
Add mechanism to override workspace per scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ docker_tag = context_value("docker.tag")
 docker_registry = context_value("docker.registry")
 ```
 
+See also: [Scoped Context Values](#scoped-context-values)
+
 ------------------------------------------------------------------------
 
 ## Core Concepts
@@ -142,7 +144,8 @@ actually happens when a step runs.
 
 Built-in actions include:
 
-- `ShellAction`: Runs a shell command.
+- `ShellAction`: Runs a shell command in the directory referenced by
+  `job_workspace`.
 - `ShellActionBuilder`: Dynamically creates parameterized shell actions
   for common CLI tools.
 - You can also define your own custom actions.
@@ -229,8 +232,8 @@ Built-in condition helpers:
 - `scope_succeeding(scope)`: True if the given scope has no errors
 - `scope_status(scope, status...)`: True if the given scope status
   matches one of the provided statuses
-- `scope_condition(value, func=None, reason=None)`: Evaluate `value` as a
-  boolean, optionally transforming it using `func`.
+- `scope_condition(value, func=None, reason=None)`: Evaluate `value` as
+  a boolean, optionally transforming it using `func`.
 
 **Example:**
 
@@ -280,11 +283,88 @@ url = lazy_format("https://{hostname}:{port}/{path}")
 
 # Access the current context (deferred)
 context = job_context
+
+# The current job workspace (defaults to .)
+workspace = job_workspace
 ```
 
 Deferred values must be resolved at execution time using
 `resolve_value`, `resolve_values`, `resolve_map`, etc. All built-in
 actions automatically resolve these values when they run.
+
+#### Scoped Context Values
+
+Context values can be associated with a *scope path* (e.g. 
+`job.stage.step.key`) to override values defined at broader scopes. When
+a value is resolved with `context_value("key")` or
+`JobContext.get_value("key")`, the most specific scoped value is
+returned.
+
+For example, values passed on the command line:
+
+    --value key=value --value job.stage.step2.key=scoped-value
+
+``` python
+with JobBuilder("job") as job:
+    with job.stage("stage") as stage:
+        with stage.step("step1") as step:
+            # Prints "value"
+            step.action = lambda ctx: print(ctx.get_value("key"))
+        with stage.step("step2") as step:
+            # Prints "scoped-value"
+            step.action = lambda ctx: print(ctx.get_value("key"))
+```
+
+Scoped values can also be provided directly in the job definition. This
+allows you to override context values programmatically:
+
+    --value key=value
+
+``` python
+with JobBuilder("job") as job:
+    with job.stage("stage") as stage:
+        with stage.step("step1") as step:
+            # Prints "value"
+            step.action = lambda ctx: print(ctx.get_value("key"))
+        with stage.step("step2") as step:
+            # Override within this scope
+            step.set_value("key", "scoped-value")
+            # Prints "scoped-value"
+            step.action = lambda ctx: print(ctx.get_value("key"))
+```
+
+##### Resolution Order
+
+When resolving a context value, the framework searches from the most
+specific scope outward:
+
+1.  `job.stage.step.key`
+2.  `job.stage.key`
+3.  `job.key`
+4.  `key`
+
+The first match found is returned.
+
+##### Precedence of Values
+
+When both a job definition and the command line provide a value for the
+same key, the command line takes precedence. This follows the common
+convention of treating runtime user input as the strongest signal of
+intent.
+
+For example:
+
+    --value job.stage.step.key=cli-value
+
+``` python
+with JobBuilder("job") as job:
+    with job.stage("stage") as stage:
+        with stage.step("step") as step:
+            # Definition-time default
+            step.set_value("key", "def-value")
+            # Will print "cli-value"
+            step.action = lambda ctx: print(ctx.get_value("key"))
+```
 
 ### Concurrent Scopes
 

--- a/src/rkojob/__init__.py
+++ b/src/rkojob/__init__.py
@@ -689,6 +689,10 @@ class JobScope(JobScopeID, Protocol):
     def concurrent(self) -> bool:
         """:returns: Whether the scope should be executed concurrently."""
 
+    @property
+    def values(self) -> Values:
+        """:returns: Scoped values that will be added to the context."""
+
 
 @runtime_checkable
 class JobGroupScope(JobScope, Protocol):

--- a/src/rkojob/__init__.py
+++ b/src/rkojob/__init__.py
@@ -13,6 +13,7 @@ from contextlib import contextmanager
 from copy import copy
 from datetime import datetime
 from enum import Enum, auto
+from pathlib import Path
 from typing import (
     Any,
     Callable,
@@ -585,6 +586,34 @@ class JobContext(Protocol):
          context.
         """
 
+    def get_value(
+        self, key: ValueKey[T] | str, coercer: Callable[[Any], T] | None = None, default: T | NoValueType = NoValue
+    ) -> T:
+        """
+        Get the value associated with the provided `key` from this context's values. If no value is present a
+        ``NoValueError`` is raised (not a ``KeyError``).
+
+        :param key: A `ValueKey` or `str` key.
+        :param coercer: An optional function to convert the raw value to the
+         expected type.
+        :param default: An optional default to use if no value is found; will
+         be set and returned.
+        :returns: A value of type `T`.
+        """
+
+    def has_value(self, key: ValueKey[T] | str) -> bool:
+        """
+        Check whether a value exists associated with the provided *key* in the context's values.
+        """
+
+    def set_value(self, key: ValueKey[T] | str, value: ValueOrRef[T]) -> None:
+        """
+        Sets or adds a `value` associated with the provided `key` to this context's values.
+
+        :param key: The key to associate the value with.
+        :param value: The value to add to this ``Values`` instance.
+        """
+
     @property
     def events(self) -> JobStatus:
         """
@@ -950,7 +979,7 @@ def resolve_value(
 
     if isinstance(value, JobCallable):
         # The value is JobCallable that takes a
-        # JobContext as a arg and returns a value.
+        # JobContext as an arg and returns a value.
         if context:
             return value(context)
         if raise_no_value:
@@ -1101,39 +1130,7 @@ class context_value(ValueKey[T]):
         self._default: T | NoValueType = default
 
     def __call__(self, context: JobContext) -> T:
-        value: Any = NoValue
-        # Get the names of the current scopes
-        scopes: list[str] = [scope.name for scope in context.scopes]
-        # Generate a list of keys that we will try prefixed with the scopes (see docstring)
-        keys: list[str] = [f"{'.'.join(scopes[:i])}.{self.name}" for i in range(len(scopes), 0, -1)]
-
-        # Try scope-prefixed keys first
-        for key in keys:
-            if context.values.has_value(key):
-                value = context.values.get(key)
-                break
-
-        if value is NoValue:
-            # No value was found using prefixed keys. Try the bare key.
-
-            if not context.values.has_value(self) and not isinstance(self._default, NoValueType):
-                # The context does not have the value but a
-                # default was provided. Set it and allow it to
-                # be looked up below.
-                self.set(context, self._default)
-
-            try:
-                value = context.values.get(self)
-            except NoValueError:
-                message: str = f"No context value found for key '{self}'"
-                if keys:
-                    message += f" (first tried: {keys})."
-                raise NoValueError(message)
-
-        if self._coercer:
-            value = self._coercer(value)
-
-        return cast(T, value)
+        return context.get_value(self.name, coercer=self._coercer, default=self._default)
 
     def set(self, context: JobContext, value: ValueOrRef[T]) -> None:
         """
@@ -1143,7 +1140,7 @@ class context_value(ValueKey[T]):
         :param context: The context to set the value for.
         :param value: The value to set in the context.
         """
-        context.values.set(self, value)
+        context.set_value(self.name, value)
 
     def __repr__(self) -> str:
         if self._coercer:
@@ -1156,6 +1153,10 @@ environment_variable: type[EnvironmentVariable] = EnvironmentVariable
 
 value_ref: type[ValueRef] = ValueRef
 """Convenience alias for a value held in a ValueRef"""
+
+
+job_workspace: context_value[Path | str] = context_value("workspace", default=".")
+"""Current job workspace. Defaults to `.`"""
 
 
 class job_scope:

--- a/src/rkojob/actions.py
+++ b/src/rkojob/actions.py
@@ -16,6 +16,7 @@ from rkojob import (
     JobException,
     JobResolvableValue,
     assign_value,
+    job_workspace,
     resolve_map,
     resolve_value,
     resolve_values,
@@ -75,6 +76,15 @@ class ShellAction(JobAction):
     def action(self, context: JobContext) -> None:
         args: list[Any] = resolve_values(self._args, context=context)
         kwargs: dict[str, Any] = resolve_map(self._kwargs, context=context)
+
+        if "cwd" not in kwargs:
+            # If cwd was not provided, default to job_workspace (if set)
+            workspace: Path | str | None = resolve_value(job_workspace, context=context)
+            if workspace is not None:
+                workspace_path: Path = Path(workspace).absolute()
+                if workspace_path is not None and workspace_path != Path.cwd():
+                    kwargs["cwd"] = workspace
+
         shell: Shell = Shell(**kwargs)
 
         command: str = shlex.join(args)

--- a/src/rkojob/context.py
+++ b/src/rkojob/context.py
@@ -7,7 +7,9 @@ from __future__ import annotations
 
 from typing import (
     Any,
+    Callable,
     Tuple,
+    cast,
 )
 
 from rkojob import (
@@ -27,8 +29,12 @@ from rkojob import (
     JobScopeStatus,
     JobStatus,
     JobTeardownScope,
+    T,
+    ValueKey,
+    ValueOrRef,
     Values,
     create_context_id,
+    resolve_value,
 )
 from rkojob.delegates import Delegate
 from rkojob.events import (
@@ -41,6 +47,7 @@ from rkojob.events import (
     JobStatusImpl,
 )
 from rkojob.factories import JobFuturesFactory
+from rkojob.values import NoValue, NoValueError, NoValueType
 
 
 class JobScopeStatuses(JobEventHandler):
@@ -412,6 +419,58 @@ class JobContextImpl(JobContext, JobEventHandler):
     @property
     def values(self) -> Values:
         return self._shared_state.values
+
+    def get_value(
+        self, key: ValueKey[T] | str, coercer: Callable[[Any], T] | None = None, default: T | NoValueType = NoValue
+    ) -> T:
+        value: Any = NoValue
+
+        # Try scope-prefixed keys first
+        keys: list[str] = self._get_scoped_keys(key)
+        for k in keys:
+            if self.values.has_value(k):
+                value = self.values.get(k)
+                break
+
+        if value is NoValue:
+            # No value was found using prefixed keys. Try the bare key.
+            if not self.values.has_value(key) and not isinstance(default, NoValueType):
+                # The context does not have the value but a
+                # default was provided. Set it and allow it to
+                # be looked up below.
+                self.set_value(key, default)
+
+            try:
+                value = self.values.get(key)
+            except NoValueError:
+                message: str = f"No context value found for key '{key}'"
+                if keys:
+                    message += f" (first tried: {keys})."
+                raise NoValueError(message)
+
+        value = resolve_value(value, context=self)
+
+        if coercer:
+            value = coercer(value)
+
+        return cast(T, value)
+
+    def has_value(self, key: ValueKey[T] | str) -> bool:
+        keys: list[str] = self._get_scoped_keys(key)
+        for k in keys:
+            if self.values.has_value(k):
+                return True
+        return self.values.has_value(key)
+
+    def _get_scoped_keys(self, key: ValueKey[T] | str) -> list[str]:
+        # Get the names of the current scopes
+        scopes: list[str] = [scope.name for scope in self.scopes]
+        # Generate a list of keys that we will try prefixed with the scopes (see docstring)
+        keys: list[str] = [f"{'.'.join(scopes[:i])}.{key}" for i in range(len(scopes), 0, -1)]
+        return keys
+
+    def set_value(self, key: ValueKey[T] | str, value: ValueOrRef[T]) -> None:
+        self.values.set(key, value)
 
     def __str__(self) -> str:
         return f"context({self.id})"

--- a/src/rkojob/job.py
+++ b/src/rkojob/job.py
@@ -5,8 +5,10 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from contextlib import AbstractContextManager, contextmanager
 from enum import Enum, auto
+from pathlib import Path
 from typing import Any, Generator, Generic, TypeVar
 
 from rkojob import (
@@ -17,9 +19,13 @@ from rkojob import (
     JobIdType,
     JobScopeID,
     JobScopeType,
+    ValueKey,
+    Values,
     create_scope_id,
     delegate,
+    job_workspace,
 )
+from rkojob.values import ValueOrRef
 
 
 class JobScopes(Enum):
@@ -66,6 +72,7 @@ class JobStep(JobScopeIDMixin, Generic[A]):
         skip_if: JobConditionalType | None = None,
         concurrent: bool = False,
         id: JobIdType | None = None,
+        values: Values | None = None,
     ) -> None:
         self._name: str = name
 
@@ -73,7 +80,8 @@ class JobStep(JobScopeIDMixin, Generic[A]):
         self._run_if: JobConditionalType | None = run_if
         self._skip_if: JobConditionalType | None = skip_if
         self._concurrent: bool = concurrent
-        self._id = id or create_scope_id()
+        self._id: str = id or create_scope_id()
+        self._values: Values = values or Values()
 
         if action:
             self.action = action
@@ -117,6 +125,10 @@ class JobStep(JobScopeIDMixin, Generic[A]):
     def skip_if(self, value: JobConditionalType | None) -> None:
         self._skip_if = value
 
+    @property
+    def values(self) -> Values:
+        return self._values
+
     def __str__(self) -> str:
         return f"{self.type} {self.name}"
 
@@ -134,6 +146,7 @@ class JobGroup(JobScopeIDMixin):
         skip_if: JobConditionalType | None = None,
         concurrent: bool = False,
         id: JobIdType | None = None,
+        values: Values | None = None,
     ):
         self._name: str = name
         if scopes is None:
@@ -143,6 +156,7 @@ class JobGroup(JobScopeIDMixin):
         self._skip_if: JobConditionalType | None = skip_if
         self._concurrent: bool = concurrent
         self._id: JobIdType = id or create_scope_id()
+        self._values: Values = values or Values()
 
     @property
     def name(self) -> str:
@@ -179,6 +193,10 @@ class JobGroup(JobScopeIDMixin):
     def skip_if(self, value: JobConditionalType | None) -> None:
         self._skip_if = value
 
+    @property
+    def values(self) -> Values:
+        return self._values
+
     def __str__(self) -> str:
         return f"{self.type} {self.name}"
 
@@ -194,8 +212,9 @@ class JobStage(JobGroup):
         scopes: list[JobGroup | JobStep[Any]] | None = None,
         concurrent: bool = False,
         id: JobIdType | None = None,
+        values: Values | None = None,
     ) -> None:
-        super().__init__(name, scopes, concurrent=concurrent, id=id)
+        super().__init__(name, scopes, concurrent=concurrent, id=id, values=values)
 
     @property
     def type(self) -> JobScopeType:
@@ -208,30 +227,56 @@ class Job(JobGroup):
     """
 
     def __init__(
-        self, name: str, scopes: list[JobGroup | JobStage | JobStep[Any]] | None = None, id: JobIdType | None = None
+        self,
+        name: str,
+        scopes: list[JobGroup | JobStage | JobStep[Any]] | None = None,
+        id: JobIdType | None = None,
+        values: Values | None = None,
     ) -> None:
-        super().__init__(name, scopes, concurrent=False, id=id)
+        super().__init__(name, scopes, concurrent=False, id=id, values=values)
 
     @property
     def type(self) -> JobScopeType:
         return JobScopes.JOB
 
 
-class JobStepBuilder(AbstractContextManager, JobScopeIDMixin):
-    def __init__(self, name: str, concurrent: bool = False) -> None:
-        self._name: str = name
+T_co = TypeVar("T_co", covariant=True)
+T = TypeVar("T")
 
-        self.builds_type: JobScopeType = JobScopes.STEP
+
+class JobBuilderBase(AbstractContextManager, JobScopeIDMixin, ABC, Generic[T_co]):
+    def __init__(self, name: str, builds_type: JobScopeType, workspace: ValueOrRef[Path | str] | None = None) -> None:
+        self._name: str = name
+        self.builds_type: JobScopeType = builds_type
         self._id: JobIdType = create_scope_id()
 
-        self.action: JobCallable[None] | None = None
         self.teardown: Delegate[[JobContext], None] = Delegate(continue_on_error=True)
-        self.run_if: JobConditionalType | None = None
-        self.skip_if: JobConditionalType | None = None
-        self.concurrent: bool = concurrent
+        self.values: Values = Values()
+        if workspace is not None:
+            self.set_value(job_workspace, workspace)
+
+    def set_value(self, key: ValueKey[T] | str, value: ValueOrRef[T]) -> None:
+        self.values.set(key, value)
 
     def __exit__(self, exc_type, exc_value, traceback, /):
         pass
+
+    @abstractmethod
+    def build(self) -> T_co:  # pragma: no cover
+        pass
+
+    def __str__(self) -> str:
+        return f"{self.builds_type} {self._name}"
+
+
+class JobStepBuilder(JobBuilderBase[JobStep]):
+    def __init__(self, name: str, concurrent: bool = False, workspace: ValueOrRef[Path | str] | None = None) -> None:
+        super().__init__(name, JobScopes.STEP, workspace=workspace)
+
+        self.action: JobCallable[None] | None = None
+        self.run_if: JobConditionalType | None = None
+        self.skip_if: JobConditionalType | None = None
+        self.concurrent: bool = concurrent
 
     def build(self) -> JobStep:
         step: JobStep = JobStep(
@@ -241,39 +286,34 @@ class JobStepBuilder(AbstractContextManager, JobScopeIDMixin):
             skip_if=self.skip_if,
             id=self._id,
             concurrent=self.concurrent,
+            values=self.values,
         )
         step.teardown += self.teardown
         return step
 
-    def __str__(self) -> str:
-        return f"{self.builds_type} {self._name}"
 
-
-class JobStageGroupBuilder(AbstractContextManager, JobScopeIDMixin):
-    def __init__(self, name: str, concurrent: bool = False) -> None:
-        self._name: str = name
-
-        self.builds_type: JobScopeType = JobScopes.GROUP
-        self._id: JobIdType = create_scope_id()
+class JobStageGroupBuilder(JobBuilderBase[JobGroup]):
+    def __init__(self, name: str, concurrent: bool = False, workspace: ValueOrRef[Path | str] | None = None) -> None:
+        super().__init__(name, JobScopes.GROUP, workspace=workspace)
 
         self._scopes: list[JobGroup | JobStage | JobStep[Any]] = []
-        self.teardown: Delegate[[JobContext], None] = Delegate(continue_on_error=True)
         self.run_if: JobConditionalType | None = None
         self.skip_if: JobConditionalType | None = None
         self.concurrent: bool = concurrent
 
-    def __exit__(self, exc_type, exc_value, traceback, /):
-        pass
-
     @contextmanager
-    def group(self, name: str, concurrent: bool = False) -> Generator[JobStageGroupBuilder, None, None]:
-        builder: JobStageGroupBuilder = JobStageGroupBuilder(name, concurrent=concurrent)
+    def group(
+        self, name: str, concurrent: bool = False, workspace: ValueOrRef[Path | str] | None = None
+    ) -> Generator[JobStageGroupBuilder, None, None]:
+        builder: JobStageGroupBuilder = JobStageGroupBuilder(name, concurrent=concurrent, workspace=workspace)
         yield builder
         self.add_scope(builder.build())
 
     @contextmanager
-    def step(self, name: str, concurrent: bool = False) -> Generator[JobStepBuilder, None, None]:
-        builder: JobStepBuilder = JobStepBuilder(name, concurrent=concurrent)
+    def step(
+        self, name: str, concurrent: bool = False, workspace: ValueOrRef[Path | str] | None = None
+    ) -> Generator[JobStepBuilder, None, None]:
+        builder: JobStepBuilder = JobStepBuilder(name, concurrent=concurrent, workspace=workspace)
         yield builder
         self.add_scope(builder.build())
 
@@ -288,45 +328,42 @@ class JobStageGroupBuilder(AbstractContextManager, JobScopeIDMixin):
             skip_if=self.skip_if,
             concurrent=self.concurrent,
             id=self._id,
+            values=self.values,
         )
         group.teardown += self.teardown
         return group
 
-    def __str__(self) -> str:
-        return f"{self.builds_type} {self._name}"
 
-
-class JobGroupBuilder(AbstractContextManager, JobScopeIDMixin):
-    def __init__(self, name: str, concurrent: bool = False) -> None:
-        self._name: str = name
-
-        self.builds_type: JobScopeType = JobScopes.GROUP
-        self._id: JobIdType = create_scope_id()
+class JobGroupBuilder(JobBuilderBase[JobGroup]):
+    def __init__(self, name: str, concurrent: bool = False, workspace: ValueOrRef[Path | str] | None = None) -> None:
+        super().__init__(name, JobScopes.GROUP, workspace=workspace)
 
         self._scopes: list[JobGroup | JobStage | JobStep[Any]] = []
-        self.teardown: Delegate[[JobContext], None] = Delegate(continue_on_error=True)
         self.run_if: JobConditionalType | None = None
         self.skip_if: JobConditionalType | None = None
         self.concurrent: bool = concurrent
 
-    def __exit__(self, exc_type, exc_value, traceback, /):
-        pass
-
     @contextmanager
-    def group(self, name: str, concurrent: bool = False) -> Generator[JobGroupBuilder, None, None]:
-        builder: JobGroupBuilder = JobGroupBuilder(name, concurrent=concurrent)
+    def group(
+        self, name: str, concurrent: bool = False, workspace: ValueOrRef[Path | str] | None = None
+    ) -> Generator[JobGroupBuilder, None, None]:
+        builder: JobGroupBuilder = JobGroupBuilder(name, concurrent=concurrent, workspace=workspace)
         yield builder
         self.add_scope(builder.build())
 
     @contextmanager
-    def stage(self, name: str, concurrent: bool = False) -> Generator[JobStageBuilder, None, None]:
-        builder: JobStageBuilder = JobStageBuilder(name, concurrent=concurrent)
+    def stage(
+        self, name: str, concurrent: bool = False, workspace: ValueOrRef[Path | str] | None = None
+    ) -> Generator[JobStageBuilder, None, None]:
+        builder: JobStageBuilder = JobStageBuilder(name, concurrent=concurrent, workspace=workspace)
         yield builder
         self.add_scope(builder.build())
 
     @contextmanager
-    def step(self, name: str, concurrent: bool = False) -> Generator[JobStepBuilder, None, None]:
-        builder: JobStepBuilder = JobStepBuilder(name, concurrent=concurrent)
+    def step(
+        self, name: str, concurrent: bool = False, workspace: ValueOrRef[Path | str] | None = None
+    ) -> Generator[JobStepBuilder, None, None]:
+        builder: JobStepBuilder = JobStepBuilder(name, concurrent=concurrent, workspace=workspace)
         yield builder
         self.add_scope(builder.build())
 
@@ -341,37 +378,32 @@ class JobGroupBuilder(AbstractContextManager, JobScopeIDMixin):
             skip_if=self.skip_if,
             concurrent=self.concurrent,
             id=self._id,
+            values=self.values,
         )
         group.teardown += self.teardown
         return group
 
-    def __str__(self) -> str:
-        return f"{self.builds_type} {self._name}"
 
-
-class JobStageBuilder(JobScopeIDMixin, AbstractContextManager):
-    def __init__(self, name: str, concurrent: bool = False) -> None:
-        self._name: str = name
-
-        self.builds_type: JobScopeType = JobScopes.STAGE
-        self._id: JobIdType = create_scope_id()
+class JobStageBuilder(JobBuilderBase[JobStage]):
+    def __init__(self, name: str, concurrent: bool = False, workspace: ValueOrRef[Path | str] | None = None) -> None:
+        super().__init__(name, JobScopes.STAGE, workspace=workspace)
 
         self._scopes: list[JobGroup | JobStep[Any]] = []
-        self.teardown: Delegate[[JobContext], None] = Delegate(continue_on_error=True)
         self.concurrent: bool = concurrent
 
-    def __exit__(self, exc_type, exc_value, traceback, /):
-        pass
-
     @contextmanager
-    def group(self, name: str, concurrent: bool = False) -> Generator[JobStageGroupBuilder, None, None]:
-        builder: JobStageGroupBuilder = JobStageGroupBuilder(name, concurrent=concurrent)
+    def group(
+        self, name: str, concurrent: bool = False, workspace: ValueOrRef[Path | str] | None = None
+    ) -> Generator[JobStageGroupBuilder, None, None]:
+        builder: JobStageGroupBuilder = JobStageGroupBuilder(name, concurrent=concurrent, workspace=workspace)
         yield builder
         self.add_scope(builder.build())
 
     @contextmanager
-    def step(self, name: str, concurrent: bool = False) -> Generator[JobStepBuilder, None, None]:
-        builder: JobStepBuilder = JobStepBuilder(name, concurrent=concurrent)
+    def step(
+        self, name: str, concurrent: bool = False, workspace: ValueOrRef[Path | str] | None = None
+    ) -> Generator[JobStepBuilder, None, None]:
+        builder: JobStepBuilder = JobStepBuilder(name, concurrent=concurrent, workspace=workspace)
         yield builder
         self.add_scope(builder.build())
 
@@ -379,40 +411,40 @@ class JobStageBuilder(JobScopeIDMixin, AbstractContextManager):
         self._scopes.append(scope)
 
     def build(self) -> JobStage:
-        stage: JobStage = JobStage(name=self._name, scopes=self._scopes, concurrent=self.concurrent, id=self._id)
+        stage: JobStage = JobStage(
+            name=self._name, scopes=self._scopes, concurrent=self.concurrent, id=self._id, values=self.values
+        )
         stage.teardown += self.teardown
         return stage
 
-    def __str__(self) -> str:
-        return f"{self.builds_type} {self._name}"
 
+class JobBuilder(JobBuilderBase[Job]):
+    def __init__(self, name: str, workspace: ValueOrRef[Path | str] | None = None) -> None:
+        super().__init__(name, JobScopes.JOB, workspace=workspace)
 
-class JobBuilder(JobScopeIDMixin, AbstractContextManager):
-    def __init__(self, name: str) -> None:
-        self._name: str = name
         self._scopes: list[JobStage | JobGroup | JobStep[Any]] = []
-        self.teardown: Delegate[[JobContext], None] = Delegate(continue_on_error=True)
-        self._id: JobIdType = create_scope_id()
-        self.builds_type: JobScopeType = JobScopes.JOB
-
-    def __exit__(self, exc_type, exc_value, traceback, /):
-        pass
 
     @contextmanager
-    def group(self, name: str, concurrent: bool = False) -> Generator[JobGroupBuilder, None, None]:
-        builder: JobGroupBuilder = JobGroupBuilder(name, concurrent=concurrent)
+    def group(
+        self, name: str, concurrent: bool = False, workspace: ValueOrRef[Path | str] | None = None
+    ) -> Generator[JobGroupBuilder, None, None]:
+        builder: JobGroupBuilder = JobGroupBuilder(name, concurrent=concurrent, workspace=workspace)
         yield builder
         self.add_scope(builder.build())
 
     @contextmanager
-    def stage(self, name: str, concurrent: bool = False) -> Generator[JobStageBuilder, None, None]:
-        builder: JobStageBuilder = JobStageBuilder(name, concurrent=concurrent)
+    def stage(
+        self, name: str, concurrent: bool = False, workspace: ValueOrRef[Path | str] | None = None
+    ) -> Generator[JobStageBuilder, None, None]:
+        builder: JobStageBuilder = JobStageBuilder(name, concurrent=concurrent, workspace=workspace)
         yield builder
         self.add_scope(builder.build())
 
     @contextmanager
-    def step(self, name: str, concurrent: bool = False) -> Generator[JobStepBuilder, None, None]:
-        builder: JobStepBuilder = JobStepBuilder(name, concurrent=concurrent)
+    def step(
+        self, name: str, concurrent: bool = False, workspace: ValueOrRef[Path | str] | None = None
+    ) -> Generator[JobStepBuilder, None, None]:
+        builder: JobStepBuilder = JobStepBuilder(name, concurrent=concurrent, workspace=workspace)
         yield builder
         self.add_scope(builder.build())
 
@@ -420,9 +452,6 @@ class JobBuilder(JobScopeIDMixin, AbstractContextManager):
         self._scopes.append(scope)
 
     def build(self) -> Job:
-        job: Job = Job(name=self._name, scopes=self._scopes, id=self._id)
+        job: Job = Job(name=self._name, scopes=self._scopes, id=self._id, values=self.values)
         job.teardown += self.teardown
         return job
-
-    def __str__(self) -> str:
-        return f"{self.builds_type} {self._name}"

--- a/src/rkojob/runner.py
+++ b/src/rkojob/runner.py
@@ -82,6 +82,10 @@ class JobRunnerImpl:
         # Run and then teardown a scope.
         # If the scope is a group, recursively run and teardown child scopes.
 
+        # Inject the scope's values first. These might be referenced in
+        # the run/skip conditions.
+        self._inject_scope_values(context, scope)
+
         should_skip: bool
         skip_reason: str
         should_skip, skip_reason = self._should_skip(context, scope)
@@ -95,6 +99,19 @@ class JobRunnerImpl:
             self._run_concurrent_scope(context, scope)
         else:
             self._real_run_scope(context, scope)
+
+    def _inject_scope_values(self, context: JobContext, scope: JobScope) -> None:
+        if not isinstance(scope, JobScope):
+            # In case a non-scope is passed in at runtime
+            return
+        prefix: str = ".".join([scope.name for scope in context.scopes])
+        prefix = f"{prefix}.{scope.name}" if prefix else scope.name
+        for key in scope.values.keys():
+            k: str = f"{prefix}.{key}"
+            if not context.values.has_value(k):
+                # Only inject value if it doesn't already exist
+                # For example, don't override values passed in via CLI
+                context.values.set(k, scope.values.get(key))
 
     def _run_concurrent_scope(self, context: JobContext, scope: JobScope) -> None:
         # Run a scope (and any child scopes) concurrently within the current scope.

--- a/tests/test_rkojob/test_actions.py
+++ b/tests/test_rkojob/test_actions.py
@@ -9,7 +9,7 @@ from tempfile import TemporaryDirectory
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
-from rkojob import JobContext, JobException, ValueRef, create_scope_id
+from rkojob import JobContext, JobException, NoValue, ValueRef, Values, create_scope_id
 from rkojob.actions import ShellAction, ShellActionBuilder, VerifyPythonTestStructure
 from rkojob.factories import JobContextFactory
 from rkojob.util import ShellException, ShellResult
@@ -20,6 +20,9 @@ class TestShellAction(TestCase):
         context = MagicMock(spec=JobContext)
         context.events.section = MagicMock()
         context.events.output = MagicMock()
+        context.values = Values()
+        context.get_value = lambda key, coercer=None, default=NoValue: context.values.get_or_else(key, default)
+
         return context
 
     @patch("rkojob.actions.Shell")
@@ -47,6 +50,16 @@ class TestShellAction(TestCase):
         expected_command = shlex.join(("echo", "ok")) + " (env={'VAR': 'value'})"
         context.events.section.assert_called_once_with(f"Executing {expected_command}")
         mock_shell_cls.assert_called_once_with(env={"VAR": "value"})
+        mock_shell_cls().assert_called_once_with("echo", "ok")
+
+    @patch("rkojob.actions.Shell")
+    def test_job_workspace(self, mock_shell_cls):
+        context = self.make_context()
+        context.values.set("workspace", "/some/path")
+
+        sut = ShellAction("echo", "ok")
+        sut.action(context)
+        mock_shell_cls.assert_called_once_with(cwd="/some/path")
         mock_shell_cls().assert_called_once_with("echo", "ok")
 
     @patch("rkojob.actions.Shell")
@@ -155,7 +168,7 @@ class TestShellActionBuilder(TestCase):
     def test(self, mock_shell_type) -> None:
         sut = ShellActionBuilder("tool").command.sub_command("-v", enable_feature=True, keyword_arg="value")
         self.assertIsInstance(sut, ShellAction)
-        sut.action(MagicMock())
+        sut.action(MagicMock(get_value=lambda key, coercer=None, default=None: None))
         mock_shell_type.assert_called_once_with(show_stdout=False, show_stderr=False)
         mock_shell_type().assert_called_once_with(
             "tool", "command", "sub-command", "-v", "--enable-feature", "--keyword-arg", "value"
@@ -167,7 +180,7 @@ class TestShellActionBuilder(TestCase):
             "-v", enable_feature=True, keyword_arg="value"
         )
         self.assertIsInstance(sut, ShellAction)
-        sut.action(MagicMock())
+        sut.action(MagicMock(get_value=lambda key, coercer=None, default=None: None))
         mock_shell_type.assert_called_once_with(show_stdout=True, env={"var": "value"}, show_stderr=False)
         mock_shell_type().assert_called_once_with(
             "tool", "command", "sub-command", "-v", "--enable-feature", "--keyword-arg", "value"

--- a/tests/test_rkojob/test_actions.py
+++ b/tests/test_rkojob/test_actions.py
@@ -193,6 +193,7 @@ class StubScope:
         self.type = type
         self.id = id or create_scope_id()
         self.concurrent = False
+        self.values = Values()
 
 
 class TestVerifyPythonTestStructure(TestCase):

--- a/tests/test_rkojob/test_context.py
+++ b/tests/test_rkojob/test_context.py
@@ -16,7 +16,9 @@ from rkojob import (
     JobScopeStatus,
     Values,
     create_scope_id,
+    lazy_format,
 )
+from rkojob.coerce import as_bool, as_json_str
 from rkojob.context import (
     JobContextImpl,
     JobScopeStatuses,
@@ -30,6 +32,7 @@ from rkojob.events import (
     JobStartScopeEvent,
 )
 from rkojob.job import JobScopeIDMixin
+from rkojob.values import NoValueError
 from tests.test_rkojob.test_runner import StubGroupScope
 
 
@@ -211,6 +214,7 @@ class StubScope(JobScopeIDMixin):
             self.teardown += teardown
         self._id = id or create_scope_id()
         self.concurrent = False
+        self.values = Values()
 
     def __str__(self):
         return f"{self.type} {self.name}"
@@ -496,3 +500,78 @@ class TestJobContextImpl(TestCase):
     def test_str(self) -> None:
         sut = JobContextImpl()
         self.assertEqual(f"context({sut.id})", str(sut))
+
+    def test_get_value(self) -> None:
+        sut = JobContextImpl(values=dict(key="value"))
+        self.assertEqual("value", sut.get_value("key"))
+
+    def test_get_value_default(self) -> None:
+        sut = JobContextImpl(values=dict())
+        self.assertEqual("default", sut.get_value("key", default="default"))
+        sut.values.set("key", "value")
+        self.assertEqual("value", sut.get_value("key", default="default"))
+
+    def test_get_value_resolvable(self) -> None:
+        sut = JobContextImpl(values=dict(key=lazy_format("{k}", k="value")))
+        self.assertEqual("value", sut.get_value("key"))
+
+    def test_set_value(self) -> None:
+        sut = JobContextImpl(values=dict(key="value"))
+        self.assertEqual("value", sut.get_value("key"))
+        sut.set_value("key", "value2")
+        self.assertEqual("value2", sut.get_value("key"))
+
+    def test_get_value_raise(self) -> None:
+        sut = JobContextImpl()
+        with self.assertRaises(NoValueError) as e:
+            sut.get_value("key")
+        self.assertEqual("No context value found for key 'key'", str(e.exception))
+
+    def test_get_value_coerce(self) -> None:
+        sut = JobContextImpl(values=dict(key="True"))
+        self.assertTrue(sut.get_value("key", coercer=as_bool))
+
+    def test_get_value_coerce_to_json(self) -> None:
+        sut = JobContextImpl(values=dict(json={"key": "value"}))
+        self.assertEqual({"key": "value"}, sut.get_value("json"))
+        self.assertEqual('{"key": "value"}', sut.get_value("json", coercer=as_json_str))
+
+    def test_get_value_scopes(self) -> None:
+        sut = JobContextImpl(values={"job.key": "job_value", "key": "value"})
+        self.assertEqual("value", sut.get_value("key"))
+        with sut.events.scope(StubScope("job", StubScopeType.JOB)):
+            self.assertEqual("job_value", sut.get_value("key"))
+            self.assertEqual("job_value", sut.get_value("job.key"))
+            with sut.events.scope(StubScope("stage", StubScopeType.STAGE)):
+                self.assertEqual("job_value", sut.get_value("key"))
+
+                sut.set_value("job.stage.key", "stage_value")
+                self.assertEqual("stage_value", sut.get_value("key"))
+
+                self.assertEqual("job_value", sut.get_value("job.key"))
+
+            self.assertEqual("job_value", sut.get_value("key"))
+        self.assertEqual("value", sut.get_value("key"))
+
+    def test_get_value_scopes_raise(self) -> None:
+        sut = JobContextImpl()
+        with sut.events.scope(StubScope("job", StubScopeType.JOB)):
+            with sut.events.scope(StubScope("stage", StubScopeType.STAGE)):
+                with sut.events.scope(StubScope("step", StubScopeType.STEP)):
+                    with self.assertRaises(NoValueError) as e:
+                        sut.get_value("key")
+                    self.assertEqual(
+                        "No context value found for key 'key' "
+                        "(first tried: ['job.stage.step.key', 'job.stage.key', 'job.key']).",
+                        str(e.exception),
+                    )
+
+    def test_has_value(self) -> None:
+        sut = JobContextImpl(values={"key": "value", "job.stage.step.key2": "step_value"})
+        self.assertTrue(sut.has_value("key"))
+        self.assertFalse(sut.has_value("key2"))
+        with sut.events.scope(StubScope("job", StubScopeType.JOB)):
+            with sut.events.scope(StubScope("stage", StubScopeType.STAGE)):
+                with sut.events.scope(StubScope("step", StubScopeType.STEP)):
+                    self.assertTrue(sut.has_value("key"))
+                    self.assertTrue(sut.has_value("key2"))

--- a/tests/test_rkojob/test_context.py
+++ b/tests/test_rkojob/test_context.py
@@ -374,6 +374,7 @@ class TestJobContextImpl(TestCase):
             type = StubScopeType.JOB
             id = "id"
             concurrent = False
+            values = Values()
 
         non_teardown_scope = NonTeardownScope()
         sut.push_scope(non_teardown_scope)

--- a/tests/test_rkojob/test_job.py
+++ b/tests/test_rkojob/test_job.py
@@ -2,7 +2,7 @@
 #
 # This work is licensed under the terms of the MIT license.
 # For a copy, see <https://opensource.org/licenses/MIT>.
-
+from typing import Any
 from unittest import TestCase
 from unittest.mock import MagicMock
 
@@ -17,9 +17,11 @@ from rkojob.factories import JobContextFactory
 from rkojob.job import (
     Job,
     JobBuilder,
+    JobBuilderBase,
     JobGroup,
     JobGroupBuilder,
     JobScopeIDMixin,
+    JobScopes,
     JobStage,
     JobStageBuilder,
     JobStageGroupBuilder,
@@ -219,6 +221,32 @@ class TestJob(TestCase):
 
     def test_str(self) -> None:
         self.assertEqual("Job name", str(Job("name")))
+
+
+class TestJobBuilderBase(TestCase):
+    def test_init_with_workspace(self) -> None:
+        class Impl(JobBuilderBase):
+            def build(self) -> Any:
+                pass
+
+        sut = Impl(name="name", builds_type=JobScopes.JOB, workspace="workspace")
+        self.assertEqual("workspace", sut.values.get("workspace"))
+
+    def test_set_value(self) -> None:
+        class Impl(JobBuilderBase):
+            def build(self) -> Any:
+                pass
+
+        sut = Impl(name="name", builds_type=JobScopes.JOB)
+        sut.set_value("key", "value")
+        self.assertEqual("value", sut.values.get("key"))
+
+    def test_str(self) -> None:
+        class Impl(JobBuilderBase):
+            def build(self) -> Any:
+                pass
+
+        self.assertEqual("Stage foo", str(Impl("foo", builds_type=JobScopes.STAGE)))
 
 
 class TestJobStepBuilder(TestCase):

--- a/tests/test_rkojob/test_rkojob.py
+++ b/tests/test_rkojob/test_rkojob.py
@@ -3,17 +3,13 @@
 # This work is licensed under the terms of the MIT license.
 # For a copy, see <https://opensource.org/licenses/MIT>.
 from enum import Enum, auto
-from typing import Any
 from unittest import TestCase
 from unittest.mock import MagicMock
 
 from rkojob import (
     JobAction,
-    JobAssignableValue,
-    JobCallable,
     JobContext,
     JobException,
-    JobResolvableValue,
     JobScopeID,
     JobScopeStack,
     JobScopeStatus,
@@ -28,6 +24,7 @@ from rkojob import (
     job_never,
     job_scope,
     job_succeeding,
+    job_workspace,
     lazy_action,
     lazy_format,
     lazy_map_value,
@@ -41,9 +38,10 @@ from rkojob import (
     scope_succeeding,
     unassign_value,
 )
-from rkojob.coerce import as_bool, as_json_str
+from rkojob.coerce import as_path
+from rkojob.context import JobContextImpl
 from rkojob.factories import JobContextFactory
-from rkojob.values import ComputedValue, NoValueError, ValueRef, Values
+from rkojob.values import ComputedValue, NoValue, NoValueError, ValueRef, Values
 
 
 class TestJobException(TestCase):
@@ -263,102 +261,45 @@ class TestJobScopeStack(TestCase):
 
 class TestContextValue(TestCase):
     def test(self) -> None:
-        mock_context = MagicMock(values=Values(key="value"))
-        sut: JobResolvableValue[str] = context_value("key")
-        self.assertEqual("value", resolve_value(sut, context=mock_context))
+        mock_context = MagicMock()
+        resolve_value(context_value("key"), context=mock_context)
+        mock_context.get_value.assert_called_with("key", coercer=None, default=NoValue)
+
+    def test_coercer(self) -> None:
+        mock_context = MagicMock()
+        mock_coercer = MagicMock()
+        resolve_value(context_value("key", coercer=mock_coercer), context=mock_context)
+        mock_context.get_value.assert_called_with("key", coercer=mock_coercer, default=NoValue)
 
     def test_default(self) -> None:
-        mock_context = MagicMock(values=Values())
-        sut: JobResolvableValue[str] = context_value("key", default="default")
-        self.assertEqual("default", resolve_value(sut, context=mock_context))
-        self.assertEqual("default", mock_context.values.get("key"))
+        mock_context = MagicMock()
+        resolve_value(context_value("key", default="default"), context=mock_context)
+        mock_context.get_value.assert_called_with("key", coercer=None, default="default")
 
     def test_set(self) -> None:
-        mock_context = MagicMock(values=Values(key="value"))
-        sut: JobAssignableValue[str] = context_value("key")
-        assign_value(sut, "value2", context=mock_context)
-        self.assertEqual("value2", resolve_value(sut, context=mock_context))
-
-    def test_raise(self) -> None:
-        mock_context = MagicMock(values=Values())
-        sut: JobResolvableValue[str] = context_value("key")
-        with self.assertRaises(NoValueError) as e:
-            resolve_value(sut, context=mock_context, raise_no_value=True)
-        self.assertEqual("No context value found for key 'key'", str(e.exception))
-
-    def test_coerce(self) -> None:
-        mock_context = MagicMock(values=Values(key="True"))
-        sut: JobResolvableValue[bool] = context_value("key", coercer=as_bool)
-        self.assertTrue(resolve_value(sut, context=mock_context))
-
-    def test_callable(self) -> None:
-        mock_context = MagicMock(values=Values(key="True"))
-        sut: JobCallable[bool] = context_value("key", coercer=as_bool)
-        self.assertTrue(sut(mock_context))
-
-    def test_coerce_to_json(self) -> None:
-        mock_context = MagicMock(values=Values(**{"json": {"key": "value"}}))
-        sut: JobCallable[dict[str, Any]] = context_value("json")
-        self.assertEqual({"key": "value"}, sut(mock_context))
-        sut2: JobCallable[str] = context_value("json", coercer=as_json_str)
-        self.assertEqual('{"key": "value"}', sut2(mock_context))
+        mock_context = MagicMock()
+        context_value("key", default="default").set(mock_context, "value")
+        mock_context.set_value.assert_called_with("key", "value")
 
     def test_repr(self) -> None:
         self.assertEqual("context_value('key')", repr(context_value("key")))
-        self.assertEqual("context_value('key', as_bool)", repr(context_value("key", as_bool)))
 
-    def test_scopes(self) -> None:
-        sut: JobResolvableValue[str] = context_value("key")
+    def test_repr_with_coercer(self) -> None:
+        self.assertEqual("context_value('key', as_path)", repr(context_value("key", coercer=as_path)))
 
-        mock_context = MagicMock()
 
-        mock_context.scopes = (StubScope("job", 0),)
-        mock_context.values = Values(**{"job.key": "job_value", "key": "value"})
-        self.assertEqual("job_value", resolve_value(sut, context=mock_context))
+class TestJobWorkspace(TestCase):
+    def test(self) -> None:
+        self.assertEqual(".", resolve_value(job_workspace, context=JobContextImpl()))
 
-        mock_context.scopes = (StubScope("job", 0), StubScope("stage", 1))
-        self.assertEqual("job_value", resolve_value(sut, context=mock_context))
-
-        mock_context.scopes = (StubScope("job", 0), StubScope("stage", 1), StubScope("step", 2))
-        mock_context.values = Values(
-            **{
-                "job.key": "job_value",
-                "job.stage.key": "stage_value",
-                "job.stage.step.key": "step_value",
-                "key": "value",
-            }
-        )
-        self.assertEqual("step_value", resolve_value(sut, context=mock_context))
-
-        sut = context_value("job.stage.key")
-        self.assertEqual("stage_value", resolve_value(sut, context=mock_context))
-
-    def test_scopes_raise(self) -> None:
-        sut: JobResolvableValue[str] = context_value("key")
-
-        mock_context = MagicMock()
-        mock_context.scopes = (StubScope("job", 0), StubScope("stage", 1), StubScope("step", 2))
-        mock_context.values = Values()
-        with self.assertRaises(NoValueError) as e:
-            resolve_value(sut, context=mock_context, raise_no_value=True)
+    def test_override(self) -> None:
         self.assertEqual(
-            "No context value found for key 'key' "
-            "(first tried: ['job.stage.step.key', 'job.stage.key', 'job.key']).",
-            str(e.exception),
+            "workspace", resolve_value(job_workspace, context=JobContextImpl(values=dict(workspace="workspace")))
         )
-
-    def test_scopes_default(self) -> None:
-        sut: JobResolvableValue[str] = context_value("key", default="default")
-
-        mock_context = MagicMock()
-        mock_context.scopes = (StubScope("job", 0), StubScope("stage", 1), StubScope("step", 2))
-        mock_context.values = Values(
-            **{
-                "job.stage.key": "stage_value",
-            }
+        self.assertEqual(
+            as_path("workspace"),
+            resolve_value(job_workspace, context=JobContextImpl(values=dict(workspace=as_path("workspace")))),
         )
-        value = resolve_value(sut, context=mock_context, raise_no_value=True)
-        self.assertEqual("stage_value", value)
 
 
 class TestJobScope(TestCase):
@@ -496,15 +437,13 @@ class TestLazyFormat(TestCase):
     def test_with_context(self) -> None:
         ref2 = ValueRef("value2")
         sut = lazy_format("{ref.1}, {ref2}", ref2=ref2)
-        values: Values = Values()
-        values.set("ref.1", "value1")
-        self.assertEqual("value1, value2", resolve_value(sut, context=MagicMock(values=values)))
+        self.assertEqual("value1, value2", resolve_value(sut, context=JobContextImpl(values={"ref.1": "value1"})))
 
     def test_missing_key(self) -> None:
         ref2 = ValueRef("value2")
         sut = lazy_format("{ref1}, {ref2}", ref2=ref2)
         with self.assertRaises(NoValueError) as e:
-            _ = resolve_value(sut, context=MagicMock(values=Values()), raise_no_value=True)
+            _ = resolve_value(sut, context=JobContextImpl(), raise_no_value=True)
         self.assertEqual("No context value found for key 'ref1'", str(e.exception))
 
     def test_repr(self) -> None:

--- a/tests/test_rkojob/test_runner.py
+++ b/tests/test_rkojob/test_runner.py
@@ -17,14 +17,17 @@ from rkojob import (
     JobInterrupt,
     ValueKey,
     ValueRef,
+    Values,
+    context_value,
     create_scope_id,
     job_succeeding,
+    resolve_value,
     scope_failing,
     scope_succeeding,
 )
 from rkojob.delegates import Delegate
 from rkojob.factories import JobContextFactory
-from rkojob.job import JobScopeIDMixin
+from rkojob.job import JobBuilder, JobScopeIDMixin
 from rkojob.runner import JobRunnerImpl
 from rkojob.util import not_none
 
@@ -43,6 +46,7 @@ class StubScope:
             self.teardown += teardown
         self.id = id or create_scope_id()
         self.concurrent = concurrent
+        self.values = Values()
 
     def __str__(self):
         return f"{self.type} {self.name}"
@@ -624,3 +628,26 @@ class TestJobRunnerImpl(TestCase):
         sut.run(context, job)
 
         self.assertEqual(["Hello from the background!", "Hello from the foreground!"], side_effects)
+
+    def test_with_values(self) -> None:
+
+        side_effects: list[str | None] = []
+
+        def action(context: JobContext) -> None:
+            side_effects.append(resolve_value(context_value("foo"), context=context))
+
+        with JobBuilder("job") as job:
+            job.values.set("foo", "job_value")
+            with job.stage("stage") as stage:
+                stage.values.set("foo", "stage_value")
+                with stage.step("step") as step:
+                    step.values.set("foo", "step_value")
+                    step.action = action
+                with stage.step("other_step") as step:
+                    step.action = action
+            with job.step("job_step") as step:
+                step.action = action
+
+        JobRunnerImpl().run(JobContextFactory.create(), job.build())
+
+        self.assertEqual(["step_value", "stage_value", "job_value"], side_effects)

--- a/tests/test_rkojob/test_values.py
+++ b/tests/test_rkojob/test_values.py
@@ -205,6 +205,11 @@ class TestGetRefValue(TestCase):
         self.assertEqual("default", get_ref_value(ValueRef(), default="default"))
 
 
+class TestValueKey(TestCase):
+    def test_str(self) -> None:
+        self.assertEqual("name", str(ValueKey("name")))
+
+
 class TestValues(TestCase):
     def test_has_value(self) -> None:
         sut = Values(int_ref=123, str_ref="abc")


### PR DESCRIPTION
Adds a few features that allow override the current workspace per-scope. For example:

``` python
# Run terragrunt in infra/s3-assets
with job.stage("provision-s3-assets", workspace="infra/s3-assets") as stage:
    with stage.step("provision-s3-assets") as step:
        step.action = terragrunt.apply(auto_approve=True, non_interactive=True)

    with stage.step("provision-s3-assets-output") as step:
        step.action = terragrunt.output(json=True)
        bucket_id = step.action.result.map(lambda r: json.loads(r.stdout)["bucket_id"]["value"])

# Run terragrunt in infra/ecr
with job.stage("provision-ecr", workspace="infra/ecr") as stage:
    with stage.step("provision-ecr") as step:
        step.action = terragrunt.apply(auto_approve=True, non_interactive=True)

    with stage.step("provision-ecr-output") as step:
        step.action = terragrunt.output(json=True)
        apprunner_image_identifier = lazy_format("{ecr_repository_url}:{docker.tag}", ...)
```

See the changes to the readme for more details on the underlying features.