### PR TITLE
Add support for custom hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ from rkojob.values import ComputedValue
 pip = ShellActionBuilder("pip")
 cat = ShellActionBuilder("cat")
 
+server = ShellActionBuilder("scripts/server.sh")
+ci = ShellActionBuilder("scripts/ci.sh")
+
 def path_exists(path: str) -> ComputedValue[bool]:
     return ComputedValue(lambda: Path(path).exists())
 
@@ -52,7 +55,7 @@ with JobBuilder("build-test-deploy") as job_builder:
 
     with job_builder.stage("build") as build:
         with build.step("build") as step:
-            step.action = ShellAction("scripts/build.sh")
+            step.action = ci.build()
 
         with build.step("log-errors") as step:
             step.action = cat("build/errors.log")
@@ -60,11 +63,11 @@ with JobBuilder("build-test-deploy") as job_builder:
 
     with job_builder.stage("test") as test:
         with test.step("start-test-server") as step:
-            step.action = ShellAction("scripts/server.sh", "start")
-            test.teardown += ShellAction("scripts/server.sh", "stop")
+            step.action = server.start()
+            test.teardown += server.stop()
 
         with test.step("test") as step:
-            step.action = ShellAction("scripts/test.sh")
+            step.action = ci.test()
 
         with test.step("log-errors") as step:
             step.action = cat("test/errors.log")
@@ -72,7 +75,7 @@ with JobBuilder("build-test-deploy") as job_builder:
 
     with job_builder.stage("deploy") as deploy:
         with deploy.step("deploy") as step:
-            step.action = ShellAction("scripts/deploy.sh")
+            step.action = ci.deploy()
             step.skip_if = context_value("dry_run", as_bool)
 
 job = job_builder.build()
@@ -258,6 +261,120 @@ If both are set:
 
 - The scope must pass `run_if`
 - Then, it must not be blocked by `skip_if`
+
+### Custom Hooks
+
+When common job definitions are shared across projects, **custom scope
+hooks** let you inject project-specific steps or stages into a shared
+job. A hook payload is itself a `JobScope`. It can be a **single step**,
+a **multi-step stage**, or even a **group of multiple stages**.
+
+#### Behavior of hook scopes
+
+Hook scopes behave exactly like **normal child scopes** once injected
+and support all the same features as pre-defined scopes, including:
+
+- **Conditions**: `run_if` / `skip_if` apply normally to injected
+  scopes.
+- **Concurrency**: concurrent stages/steps can be injected and will run
+  in parallel.
+- **Teardown**: injected scopes trigger their own teardown logic and
+  integrate with parent teardown.
+- **Error handling**: failures propagate up through parents.
+- **Events and logging**: hook scopes emit the same events, log entries,
+  and metrics as any other scope.
+- **Nesting**: a hook payload can itself define groups, stages, and
+  steps, nesting as deeply as you like.
+
+> In short: once a scope is injected via a hook, the runner treats it no
+> differently than a pre-defined scope.
+
+#### Registering Hooks
+
+Hooks are registered with a `JobHooks` instance by **path**
+(forward-slash-separated scope path) and a `JobHook` value:
+
+- **Path** targets the scopes where the hook should attach.
+- **`JobHook`** specifies what to inject `before` and/or `after` each
+  matched scope. Each side accepts a `JobResolvableValue[JobScope]`
+  which means it can be either:
+  - a **concrete `JobScope`** (used once), or
+  - a **`ValueProvider[JobScope]`** that provides a `JobScope`, or
+  - a **factory** `JobCallable[JobScope]`
+
+See `rkojob.resolve_value` for a complete list of types that can be
+resolved.
+
+Projects typically expose a `register_hooks(hooks: JobHooks)` function
+in a module passed via `--hooks-module`, and the runner calls it during
+startup.
+
+Hook scopes are run in the order that they are registered.
+
+#### Minimal example: inject a `srcgen` step before the `build` stage
+
+``` python
+# custom_hooks.py
+
+from rkojob import JobHook, JobHooks
+from rkojob.job import JobStep
+from rkojob.actions import ShellActionBuilder
+
+srcgen = ShellActionBuilder("srcgen")
+srcgen_step = JobStep("generate-sources", action=srcgen.generate())
+
+def register_hooks(hooks: JobHooks) -> None:
+    # Inject once, before build-and-test/build
+    hooks.register("build-and-test/build", JobHook(before=srcgen_step))
+```
+
+Run with:
+
+    rkojob run --job jobs.build_and_test --hooks-module custom_hooks
+
+#### Scope path glob patterns
+
+A glob-style pattern can be used to register a hook:
+
+``` python
+# Run for every stage of `build-and-test`
+hooks.register("build-and-test/*", JobHook(before=...))
+
+# Run for every scope (group, stage, or step) under the job whose name starts with "log"
+hooks.register("build-and-test/**/log*", JobHook(after=...))
+```
+
+> ⚠️ **Note:** Factory required for multi-match
+
+If a hook can match multiple scopes (via `*` or `**`), pass a factory so
+each injection gets a fresh `JobScope` instance.
+
+``` python
+from rkojob import JobContext, job_context, JobHook, JobHooks, JobScope
+from rkojob.job import JobStep
+from rkojob.actions import ShellActionBuilder
+
+logger = ShellActionBuilder("logger")
+
+def pre_stage(_: JobContext) -> JobScope:
+    return JobStep(
+        "pre-stage-logging",
+        action=logger.log(job_context.map(lambda ctx: f"{ctx.scope} starting."))
+    )
+
+def post_stage(_: JobContext) -> JobScope:
+    return JobStep(
+        "post-stage-logging",
+        action=logger.log(job_context.map(lambda ctx: f"{ctx.scope} complete."))
+    )
+
+def register_hooks(hooks: JobHooks) -> None:
+    hooks.register("*/*", JobHook(before=pre_stage, after=post_stage))
+```
+
+Because a `JobContext` is provided when the hook is created, one could
+do some interesting things with dynamic hooks based on the current
+context, if one were so inclined.
 
 ### Deferred Evaluation
 

--- a/src/rkojob/__init__.py
+++ b/src/rkojob/__init__.py
@@ -538,6 +538,16 @@ class JobContext(Protocol):
         :returns: A `Delegate` instance that will invoke the teardown actions.
         """
 
+    def get_before_hooks(self) -> list[JobScope]:
+        """
+        Get a list of `JobScope`'s that should be executed *before* the current scope.
+        """
+
+    def get_after_hooks(self) -> list[JobScope]:
+        """
+        Get a list of `JobScope`'s that should be executed *after* the current scope.
+        """
+
     def get_futures(self, scope: JobScopeID) -> JobFutures:
         """
         Gets the ``JobFutures`` instance that can be used to execute concurrent
@@ -649,6 +659,10 @@ def create_scope_id() -> JobIdType:
     Creates a new, unique scope ID value.
     """
     return JobIdType(uuid4())
+
+
+def get_scope_path(*scopes: JobScope, sep: str = ".") -> str:
+    return sep.join([scope.name for scope in scopes])
 
 
 @runtime_checkable
@@ -1406,6 +1420,41 @@ class JobRunner(Protocol):
     """
 
     def run(self, context: JobContext, scope: JobScope) -> None: ...
+
+
+class JobHook:
+    def __init__(
+        self,
+        before: JobResolvableValue[JobScope | None] | None = None,
+        after: JobResolvableValue[JobScope | None] | None = None,
+    ) -> None:
+        self._before: JobResolvableValue[JobScope | None] | None = before
+        self._after: JobResolvableValue[JobScope | None] | None = after
+
+    def get_before(self, context: JobContext) -> JobScope | None:
+        return resolve_value(self._before, context=context)
+
+    def get_after(self, context: JobContext) -> JobScope | None:
+        return resolve_value(self._after, context=context)
+
+
+class JobHooks(Protocol):
+    """
+    A protocol for a hooks registry that allows for registering hooks at
+    runtime to be executed before or after a previously defined scope.
+    """
+
+    def register(self, path_spec: str, hook: JobHook) -> None:
+        """
+        Register a hook to be run based on a scope path spec. For example,
+        `job.*` would run the hook for every child scope of `job` and
+        `job.stage1.step2` would run the hook for `job.stage1.step2` only.
+        """
+
+    def get_hooks(self, path: str) -> list[JobHook]:
+        """
+        Get the hooks registered for the provided scope path.
+        """
 
 
 class job_action(JobAction, Generic[P, R]):

--- a/src/rkojob/cli.py
+++ b/src/rkojob/cli.py
@@ -12,9 +12,9 @@ from typing import Any, Final
 
 import yaml
 
-from rkojob import JobEventDispatcher, JobException, JobScope
+from rkojob import JobEventDispatcher, JobException, JobHooks, JobScope
 from rkojob.events import JobDirectEventDispatcher
-from rkojob.factories import JobContextFactory, JobRunnerFactory
+from rkojob.factories import JobContextFactory, JobHooksFactory, JobRunnerFactory
 from rkojob.writer import JobStatusWriter
 
 
@@ -22,7 +22,10 @@ class Cli:
 
     RUN_COMMAND: Final[str] = "run"
 
-    JOB_ARGS: Final[tuple[str, str]] = ("--job", "-j")
+    JOB_ARGS: Final[tuple[str, ...]] = ("--job", "-j")
+    VALUE_ARGS: Final[tuple[str, ...]] = ("--value", "-v")
+    VALUES_FROM_ARGS: Final[tuple[str, ...]] = ("--values-from",)
+    HOOKS_MODULE_ARGS: Final[tuple[str, ...]] = ("--hooks-module",)
 
     def main(self, argv: list[str]) -> int:  # pragma: no cover
         try:
@@ -48,9 +51,14 @@ class Cli:
         # run
         run_parser = subparsers.add_parser(self.RUN_COMMAND, help="Execute a job definition.")
         run_parser.add_argument(*self.JOB_ARGS, type=str, required=True, help="The name of the job definition to run.")
-        run_parser.add_argument("--value", "-v", action="append", dest="values", default=[])
+        run_parser.add_argument(*self.VALUE_ARGS, action="append", dest="values", default=[])
         run_parser.add_argument(
-            "--values-from", type=str, help="Path to a file containing key=value pairs to add to the context's values."
+            *self.VALUES_FROM_ARGS,
+            type=str,
+            help="Path to a file containing key=value pairs to add to the context's values.",
+        )
+        run_parser.add_argument(
+            *self.HOOKS_MODULE_ARGS, type=str, help="The name of the module that will register custom hooks."
         )
 
         return parser
@@ -62,13 +70,14 @@ class Cli:
     def run_job(self, args: Namespace) -> int:  # pragma: no cover
         job: JobScope = self.get_job(args.job)
         values: dict[str, Any] = self.read_values(args)
+        hooks: JobHooks = self.get_hooks(args.hooks_module)
 
         try:
             events: JobEventDispatcher = self.get_event_dispatcher()
             status_writer: JobStatusWriter = self.get_status_writer()
             events.add_handler(status_writer)
 
-            context = JobContextFactory.create(events=events, values=values)
+            context = JobContextFactory.create(events=events, values=values, hooks=hooks)
             JobRunnerFactory.create().run(context, job)
             return self.success()
         except Exception as e:
@@ -109,16 +118,16 @@ class Cli:
             result[k] = v
         return result
 
-    def get_job_module(self, name: str) -> ModuleType:  # pragma: no cover
+    def get_module(self, name: str) -> ModuleType:  # pragma: no cover
         try:
             return importlib.import_module(name)
         except ModuleNotFoundError as e:
-            raise ModuleNotFoundError(f"Job module not found: {name}") from e
+            raise ModuleNotFoundError(f"Module not found: {name}") from e
 
     def get_job(self, job_name: str) -> JobScope:  # pragma: no cover
         module_name: str
         module_name, job_name = self._split_module_and_job(job_name)
-        job_module: ModuleType = self.get_job_module(module_name)
+        job_module: ModuleType = self.get_module(module_name)
         job: JobScope = getattr(job_module, job_name)
         return job
 
@@ -127,6 +136,14 @@ class Cli:
         if len(module_and_job) != 2:
             raise ValueError(f"Invalid job name: '{job_name}' (expecting <module_name>.<job_name>)")
         return module_and_job[0], module_and_job[1]
+
+    def get_hooks(self, module_name: str | None) -> JobHooks:  # pragma: no cover
+        hooks: JobHooks = JobHooksFactory.create()
+        if module_name:
+            hooks_module: ModuleType = self.get_module(module_name)
+            if getattr(hooks_module, "register_hooks"):
+                hooks_module.register_hooks(hooks)
+        return hooks
 
 
 def main() -> int:  # pragma: no cover

--- a/src/rkojob/context.py
+++ b/src/rkojob/context.py
@@ -21,6 +21,7 @@ from rkojob import (
     JobException,
     JobFutures,
     JobGroupScope,
+    JobHooks,
     JobIdType,
     JobInterrupt,
     JobScope,
@@ -34,6 +35,7 @@ from rkojob import (
     ValueOrRef,
     Values,
     create_context_id,
+    get_scope_path,
     resolve_value,
 )
 from rkojob.delegates import Delegate
@@ -46,7 +48,7 @@ from rkojob.events import (
     JobStartScopeEvent,
     JobStatusImpl,
 )
-from rkojob.factories import JobFuturesFactory
+from rkojob.factories import JobFuturesFactory, JobHooksFactory
 from rkojob.values import NoValue, NoValueError, NoValueType
 
 
@@ -171,7 +173,7 @@ class JobContextState:
     State that is the same for all scopes in a context.
     """
 
-    def __init__(self, events: JobEventDispatcher | None, values: dict[str, Any] | None):
+    def __init__(self, events: JobEventDispatcher | None, values: dict[str, Any] | None, hooks: JobHooks | None):
         """
         :param events: The ``JobEventDispatcher`` that the context will use to
          generate and handle events. If ``None``, a new dispatcher will be used.
@@ -182,8 +184,11 @@ class JobContextState:
             events = JobDirectEventDispatcher()
         if values is None:
             values = {}
+        if hooks is None:
+            hooks = JobHooksFactory.create()
         self.events: JobEventDispatcher = events
         self.values: Values = Values(**values)
+        self.hooks: JobHooks = hooks
 
         self.scope_statuses: JobScopeStatuses = JobScopeStatuses()
         self.events.add_handler(self.scope_statuses)
@@ -211,6 +216,7 @@ class JobContextImpl(JobContext, JobEventHandler):
         *,
         values: dict[str, Any] | None = None,
         events: JobEventDispatcher | None = None,
+        hooks: JobHooks | None = None,
         state: JobContextState | None = None,
     ) -> None:
         """
@@ -222,7 +228,7 @@ class JobContextImpl(JobContext, JobEventHandler):
         """
         # State shared by all contexts (global)
         if state is None:
-            state = JobContextState(events=events, values=values)
+            state = JobContextState(events=events, values=values, hooks=hooks)
         self._shared_state: JobContextState = state
         # Respond to events from the events dispatcher.
         self._shared_state.events.add_handler(self)
@@ -325,6 +331,26 @@ class JobContextImpl(JobContext, JobEventHandler):
         if scope not in self._scope_stack:
             raise JobException(f"Scope {scope} is not an active scope.")
         return self._scope_stack[scope].teardown
+
+    def get_before_hooks(self) -> list[JobScope]:
+        # Hook spec uses a forward slash as a separator
+        scope_path: str = get_scope_path(*self.scopes, sep="/")
+        hooks: list[JobScope] = []
+        for h in self._shared_state.hooks.get_hooks(scope_path):
+            hook: JobScope | None = h.get_before(self)
+            if hook is not None:
+                hooks.append(hook)
+        return hooks
+
+    def get_after_hooks(self) -> list[JobScope]:
+        # Hook spec uses a forward slash as a separator
+        scope_path: str = get_scope_path(*self.scopes, sep="/")
+        hooks: list[JobScope] = []
+        for h in self._shared_state.hooks.get_hooks(scope_path):
+            hook: JobScope | None = h.get_after(self)
+            if hook is not None:
+                hooks.append(hook)
+        return hooks
 
     def get_futures(self, scope: JobScopeID) -> JobFutures:
         scope = self._resolve_scope(scope)

--- a/src/rkojob/factories.py
+++ b/src/rkojob/factories.py
@@ -3,7 +3,7 @@
 # This work is licensed under the terms of the MIT license.
 # For a copy, see <https://opensource.org/licenses/MIT>.
 
-from rkojob import JobContext, JobFutures, JobRunner
+from rkojob import JobContext, JobFutures, JobHooks, JobRunner
 
 
 class JobContextFactory:
@@ -11,7 +11,7 @@ class JobContextFactory:
     def create(cls, *args, **kwargs) -> JobContext:
         from rkojob.context import JobContextImpl
 
-        return JobContextImpl(events=kwargs.get("events"), values=kwargs.get("values"))
+        return JobContextImpl(events=kwargs.get("events"), values=kwargs.get("values"), hooks=kwargs.get("hooks"))
 
 
 class JobRunnerFactory:
@@ -20,6 +20,14 @@ class JobRunnerFactory:
         from rkojob.runner import JobRunnerImpl
 
         return JobRunnerImpl()
+
+
+class JobHooksFactory:
+    @classmethod
+    def create(cls, *args, **kwargs) -> JobHooks:
+        from rkojob.hooks import JobHooksImpl
+
+        return JobHooksImpl()
 
 
 class JobFuturesFactory:

--- a/src/rkojob/hooks.py
+++ b/src/rkojob/hooks.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2025 R.K. Oliver. All rights reserved.
+#
+# This work is licensed under the terms of the MIT license.
+# For a copy, see <https://opensource.org/licenses/MIT>.
+
+import re
+
+from rkojob import JobHook, JobHooks
+
+
+class JobHooksImpl(JobHooks):
+    def __init__(self) -> None:
+        self._patterns: dict[str, re.Pattern] = {}
+        self._hooks: dict[str, list[JobHook]] = {}
+
+    def register(self, pattern: str, hook: JobHook) -> None:
+        if pattern not in self._hooks:
+            self._hooks[pattern] = []
+        self._hooks[pattern].append(hook)
+
+    def get_hooks(self, path: str) -> list[JobHook]:
+        hooks: list[JobHook] = []
+        for pattern in self._hooks:
+            if pattern not in self._patterns:
+                self._patterns[pattern] = re.compile(self._pattern_to_regex(pattern, "/"))
+            if self._patterns[pattern].match(path):
+                hooks.extend(self._hooks[pattern])
+        return hooks
+
+    def _pattern_to_regex(self, pattern: str, sep: str) -> str:
+        segs: list[str] = pattern.split(sep)
+        sep_esc: str = re.escape(sep)
+        seg_nonsep: str = rf"[^{sep_esc}]+"
+
+        out: list[str] = ["^"]
+        i = 0
+        first = True
+
+        while i < len(segs):
+            seg = segs[i]
+            if seg == "**":
+                # Collapse consecutive **
+                while i + 1 < len(segs) and segs[i + 1] == "**":
+                    i += 1
+
+                if not first:
+                    # Zero or more additional segments
+                    out.append(rf"(?:{sep_esc}{seg_nonsep})*")
+                else:
+                    # Zero or more segments
+                    out.append(rf"(?:{seg_nonsep}(?:{sep_esc}{seg_nonsep})*)?")
+
+            else:
+                if not first:
+                    out.append(sep_esc)
+                out.append(self._segment_glob_to_regex(seg, sep))
+
+            first = False
+            i += 1
+
+        out.append("$")
+        return "".join(out)
+
+    def _segment_glob_to_regex(self, seg: str, sep: str) -> str:
+        """
+        Translate a single *segment* glob to a regex that never matches the separator.
+        Supports: *, ?, and character classes [] (with '!'/'^' negation).
+        """
+        sep_esc: str = re.escape(sep)
+        out: list[str] = []
+        i = 0
+        n = len(seg)
+
+        while i < n:
+            ch = seg[i]
+
+            if ch == "\\" and i + 1 < n:
+                # Escaped char
+                out.append(re.escape(seg[i + 1]))
+                i += 2
+                continue
+
+            if ch == "*":
+                # Match zero or more chars but not sep
+                out.append(f"[^{sep_esc}]*")
+                i += 1
+                continue
+
+            if ch == "?":
+                # Match any char but not sep
+                out.append(f"[^{sep_esc}]")
+                i += 1
+                continue
+
+            # Suggested by AI but not sure I want it yet.
+            # if ch == "[":
+            #     # Copy a character class verbatim until closing ']'
+            #     j = i + 1
+            #     if j < n and seg[j] in ("!", "^"):
+            #         j += 1  # keep negation marker inside the class
+            #     if j < n and seg[j] == "]":
+            #         j += 1  # literal ']' as first member
+            #
+            #     while j < n and seg[j] != "]":
+            #         j += 1
+            #     if j >= n:
+            #         # Unclosed class: treat '[' literally
+            #         out.append(r"\[")
+            #         i += 1
+            #     else:
+            #         # Keep the class as-is, but escape regex meta outside class context
+            #         cls = seg[i : j + 1]
+            #         out.append(cls)
+            #         i = j + 1
+            #     continue
+
+            # Literal char
+            out.append(re.escape(ch))
+            i += 1
+
+        # Anchor this segment
+        return "(?:" + "".join(out) + ")"

--- a/src/rkojob/runner.py
+++ b/src/rkojob/runner.py
@@ -2,7 +2,6 @@
 #
 # This work is licensed under the terms of the MIT license.
 # For a copy, see <https://opensource.org/licenses/MIT>.
-
 from typing import Any, cast
 
 import yaml
@@ -21,6 +20,7 @@ from rkojob import (
     JobScope,
     JobScopeID,
     JobTeardownScope,
+    get_scope_path,
     job_failing,
     job_never,
     resolve_value,
@@ -104,8 +104,9 @@ class JobRunnerImpl:
         if not isinstance(scope, JobScope):
             # In case a non-scope is passed in at runtime
             return
-        prefix: str = ".".join([scope.name for scope in context.scopes])
-        prefix = f"{prefix}.{scope.name}" if prefix else scope.name
+
+        # Context values use a dot as a separator
+        prefix: str = get_scope_path(*(*context.scopes, scope), sep=".")
         for key in scope.values.keys():
             k: str = f"{prefix}.{key}"
             if not context.values.has_value(k):
@@ -167,11 +168,19 @@ class JobRunnerImpl:
             raise self._unknown_scope(context, scope)
 
         with context.events.scope(scope):
+
             try:
+                for before_hook in context.get_before_hooks():
+                    self._run_scope(context, before_hook)
+
                 if group:
                     self._run_group(context, group)
                 elif action:
                     self._run_action(context, action)
+
+                for after_hook in context.get_after_hooks():
+                    self._run_scope(context, after_hook)
+
             finally:
                 if group:
                     # If this is a group scope, wait for any concurrent child scopes.

--- a/tests/test_rkojob/test_cli.py
+++ b/tests/test_rkojob/test_cli.py
@@ -32,6 +32,7 @@ class TestCli(TestCase):
         self.assertEqual(args.job, "pkg.mod.job")
         self.assertEqual(args.values, [])  # default
         self.assertIsNone(args.values_from)
+        self.assertIsNone(args.hooks_module)
 
     def test_parse_args_all_options(self) -> None:
         argv = [
@@ -44,11 +45,13 @@ class TestCli(TestCase):
             "b=two",
             "--values-from",
             "vals.yml",
+            "--hooks-module",
+            "some.module.my_hooks",
         ]
         args = self.sut.parse_args(argv)
         self.assertEqual(
-            (args.command, args.job, args.values, args.values_from),
-            ("run", "some.module.my_job", ["a=1", "b=two"], "vals.yml"),
+            (args.command, args.job, args.values, args.values_from, args.hooks_module),
+            ("run", "some.module.my_job", ["a=1", "b=two"], "vals.yml", "some.module.my_hooks"),
         )
 
     def test_split_module_and_job(self) -> None:

--- a/tests/test_rkojob/test_hooks.py
+++ b/tests/test_rkojob/test_hooks.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2025 R.K. Oliver. All rights reserved.
+#
+# This work is licensed under the terms of the MIT license.
+# For a copy, see <https://opensource.org/licenses/MIT>.
+
+from unittest import TestCase
+from unittest.mock import MagicMock, NonCallableMagicMock
+
+from rkojob import JobActionScope
+from rkojob.hooks import JobHook, JobHooksImpl
+
+
+class TestJobHooksImpl(TestCase):
+    def test_register(self) -> None:
+        mock_hook_1 = MagicMock()
+        mock_hook_2 = MagicMock()
+        mock_hook_3 = MagicMock()
+
+        sut = JobHooksImpl()
+        sut.register("*", mock_hook_1)
+        sut.register("job.stage", mock_hook_2)
+        sut.register("job.stage", mock_hook_3)
+
+        self.assertEqual([mock_hook_1], sut._hooks["*"])
+        self.assertEqual([mock_hook_2, mock_hook_3], sut._hooks["job.stage"])
+
+    def test_get_hooks(self) -> None:
+        mock_hook_0 = MagicMock(name="hook_0")
+        mock_hook_1 = MagicMock(name="hook_1")
+        mock_hook_2 = MagicMock(name="hook_2")
+        mock_hook_3 = MagicMock(name="hook_3")
+        mock_hook_4 = MagicMock(name="hook_4")
+        mock_hook_5 = MagicMock(name="hook_5")
+        mock_hook_6 = MagicMock(name="hook_6")
+        mock_hook_7 = MagicMock(name="hook_7")
+
+        sut = JobHooksImpl()
+        sut.register("**", mock_hook_0)
+        sut.register("*", mock_hook_1)
+        sut.register("job/*", mock_hook_2)
+        sut.register("job/stage", mock_hook_3)
+        sut.register("job/stage*/*", mock_hook_4)
+        sut.register("job/*/*/step", mock_hook_5)
+        sut.register("job/**/step", mock_hook_6)
+        sut.register("job/stage-?/step-?", mock_hook_7)
+
+        self.assertEqual([mock_hook_0, mock_hook_1], sut.get_hooks("job"))
+        self.assertEqual([mock_hook_0, mock_hook_1], sut.get_hooks("job"))
+        self.assertEqual([mock_hook_0, mock_hook_1], sut.get_hooks("foo"))
+        self.assertEqual([mock_hook_0, mock_hook_2], sut.get_hooks("job/foo"))
+        self.assertEqual([mock_hook_0, mock_hook_6], sut.get_hooks("job/foo/step"))
+        self.assertEqual([mock_hook_0, mock_hook_2, mock_hook_3], sut.get_hooks("job/stage"))
+        self.assertEqual([mock_hook_0, mock_hook_4], sut.get_hooks("job/stage-1/group-1"))
+        self.assertEqual([mock_hook_0, mock_hook_5, mock_hook_6], sut.get_hooks("job/foo/bar/step"))
+        self.assertEqual([mock_hook_0, mock_hook_5, mock_hook_6], sut.get_hooks("job/stage-1/group-1/step"))
+        self.assertEqual([mock_hook_0, mock_hook_4, mock_hook_7], sut.get_hooks("job/stage-1/step-1"))
+
+    def test_segment_glob_to_regex(self) -> None:
+        sut = JobHooksImpl()._segment_glob_to_regex
+
+        self.assertEqual(r"(?:[^\.]*)", sut("*", "."))
+        self.assertEqual(r"(?:[^\.]*[^\.]*)", sut("**", "."))
+        self.assertEqual(r"(?:[^/]*)", sut("*", "/"))
+        self.assertEqual(r"(?:[^/]*[^/]*)", sut("**", "/"))
+        self.assertEqual(r"(?:foo[^/]*)", sut("foo*", "/"))
+        self.assertEqual(r"(?:[^/]*foo)", sut("*foo", "/"))
+        self.assertEqual(r"(?:f[^/]*o)", sut("f*o", "/"))
+        self.assertEqual(r"(?:f[^/]o)", sut("f?o", "/"))
+
+        self.assertEqual(r"(?:f\?[^\.]*o)", sut("f\\?*o", "."))
+
+    def test_pattern_to_regex(self) -> None:
+        sut = JobHooksImpl()._pattern_to_regex
+
+        self.assertEqual(r"^(?:[^\.]*)$", sut("*", "."))
+        self.assertEqual(r"^(?:[^/]*)$", sut("*", "/"))
+
+        self.assertEqual(r"^(?:[^/]+(?:/[^/]+)*)?$", sut("**", "/"))
+        self.assertEqual(r"^(?:[^\.]+(?:\.[^\.]+)*)?$", sut("**.**", "."))
+
+        self.assertEqual(r"^(?:foo)(?:/[^/]+)*$", sut("foo/**", "/"))
+
+
+class TestJobHook(TestCase):
+    def test_scope(self) -> None:
+        scope = NonCallableMagicMock(spec=JobActionScope)
+        sut = JobHook(before=scope)
+        self.assertIsInstance(sut, JobHook)
+        self.assertIs(sut.get_before(MagicMock()), scope)
+        self.assertIsNone(sut.get_after(MagicMock()))
+
+    def test_callable(self) -> None:
+        scope = NonCallableMagicMock(spec=JobActionScope)
+        sut = JobHook(before=lambda x: scope)
+        self.assertIsInstance(sut, JobHook)
+        self.assertIs(sut.get_before(MagicMock()), scope)
+        self.assertIsNone(sut.get_after(MagicMock()))

--- a/tests/test_rkojob/test_runner.py
+++ b/tests/test_rkojob/test_runner.py
@@ -26,7 +26,8 @@ from rkojob import (
     scope_succeeding,
 )
 from rkojob.delegates import Delegate
-from rkojob.factories import JobContextFactory
+from rkojob.factories import JobContextFactory, JobHooksFactory
+from rkojob.hooks import JobHook
 from rkojob.job import JobBuilder, JobScopeIDMixin
 from rkojob.runner import JobRunnerImpl
 from rkojob.util import not_none
@@ -651,3 +652,42 @@ class TestJobRunnerImpl(TestCase):
         JobRunnerImpl().run(JobContextFactory.create(), job.build())
 
         self.assertEqual(["step_value", "stage_value", "job_value"], side_effects)
+
+    def test_hooks(self) -> None:
+        side_effects: list[str] = []
+        job = self._create_job(side_effects)
+        hooks = JobHooksFactory.create()
+        hooks.register(
+            "job/stage?/step?.2",
+            JobHook(before=lambda _: StubActionScope("before", StubScopeType.STEP, action=self._action(side_effects))),
+        )
+        hooks.register(
+            "job/stage?/step?.1",
+            JobHook(after=lambda _: StubActionScope("after", StubScopeType.STEP, action=self._action(side_effects))),
+        )
+        context = JobContextFactory.create(hooks=hooks)
+        JobRunnerImpl().run(context, job)
+
+        self.assertEqual(
+            [
+                "Action: job->stage1->step1.1",
+                "Action: job->stage1->step1.1->after",
+                "Action: job->stage1->step1.2->before",
+                "Action: job->stage1->step1.2",
+                "Action: job->stage2->step2.1",
+                "Action: job->stage2->step2.1->after",
+                "Action: job->stage2->step2.2->before",
+                "Action: job->stage2->step2.2",
+                "Teardown stage2: step2.2",
+                "Teardown stage2: step2.1",
+                "Action: job->stage3->step3.1",
+                "Action: job->stage3->step3.1->after",
+                "Action: job->stage3->step3.2->before",
+                "Action: job->stage3->step3.2",
+                "Teardown job: step3.2",
+                "Teardown job: step3.1",
+                "Teardown job: step1.2",
+                "Teardown job: step1.1",
+            ],
+            side_effects,
+        )


### PR DESCRIPTION
### Custom Hooks

When common job definitions are shared across projects, **custom scope
hooks** let you inject project-specific steps or stages into a shared
job. A hook payload is itself a `JobScope`. It can be a **single step**,
a **multi-step stage**, or even a **group of multiple stages**.

#### Behavior of hook scopes

Hook scopes behave exactly like **normal child scopes** once injected
and support all the same features as pre-defined scopes, including:

- **Conditions**: `run_if` / `skip_if` apply normally to injected
  scopes.
- **Concurrency**: concurrent stages/steps can be injected and will run
  in parallel.
- **Teardown**: injected scopes trigger their own teardown logic and
  integrate with parent teardown.
- **Error handling**: failures propagate up through parents.
- **Events and logging**: hook scopes emit the same events, log entries,
  and metrics as any other scope.
- **Nesting**: a hook payload can itself define groups, stages, and
  steps, nesting as deeply as you like.

> In short: once a scope is injected via a hook, the runner treats it no
> differently than a pre-defined scope.

#### Registering Hooks

Hooks are registered with a `JobHooks` instance by **path**
(forward-slash-separated scope path) and a `JobHook` value:

- **Path** targets the scopes where the hook should attach.
- **`JobHook`** specifies what to inject `before` and/or `after` each
  matched scope. Each side accepts a `JobResolvableValue[JobScope]`
  which means it can be either:
  - a **concrete `JobScope`** (used once), or
  - a **`ValueProvider[JobScope]`** that provides a `JobScope`, or
  - a **factory** `JobCallable[JobScope]`

See `rkojob.resolve_value` for a complete list of types that can be
resolved.

Projects typically expose a `register_hooks(hooks: JobHooks)` function
in a module passed via `--hooks-module`, and the runner calls it during
startup.

Hook scopes are run in the order that they are registered.

#### Minimal example: inject a `srcgen` step before the `build` stage

``` python
# custom_hooks.py

from rkojob import JobHook, JobHooks
from rkojob.job import JobStep
from rkojob.actions import ShellActionBuilder

srcgen = ShellActionBuilder("srcgen")
srcgen_step = JobStep("generate-sources", action=srcgen.generate())

def register_hooks(hooks: JobHooks) -> None:
    # Inject once, before build-and-test/build
    hooks.register("build-and-test/build", JobHook(before=srcgen_step))
```

Run with:

    rkojob run --job jobs.build_and_test --hooks-module custom_hooks

#### Scope path glob patterns

A glob-style pattern can be used to register a hook:

``` python
# Run for every stage of `build-and-test`
hooks.register("build-and-test/*", JobHook(before=...))

# Run for every scope (group, stage, or step) under the job whose name starts with "log"
hooks.register("build-and-test/**/log*", JobHook(after=...))
```

> ⚠️ **Note:** Factory required for multi-match

If a hook can match multiple scopes (via `*` or `**`), pass a factory so
each injection gets a fresh `JobScope` instance.

``` python
from rkojob import JobContext, job_context, JobHook, JobHooks, JobScope
from rkojob.job import JobStep
from rkojob.actions import ShellActionBuilder

logger = ShellActionBuilder("logger")

def pre_stage(_: JobContext) -> JobScope:
    return JobStep(
        "pre-stage-logging",
        action=logger.log(job_context.map(lambda ctx: f"{ctx.scope} starting."))
    )

def post_stage(_: JobContext) -> JobScope:
    return JobStep(
        "post-stage-logging",
        action=logger.log(job_context.map(lambda ctx: f"{ctx.scope} complete."))
    )

def register_hooks(hooks: JobHooks) -> None:
    hooks.register("*/*", JobHook(before=pre_stage, after=post_stage))
```

Because a `JobContext` is provided when the hook is created, one could
do some interesting things with dynamic hooks based on the current
context, if one were so inclined.